### PR TITLE
🚨 Fix new clippy warnings

### DIFF
--- a/core/src/libraries/scheduling/job_scheduler.rs
+++ b/core/src/libraries/scheduling/job_scheduler.rs
@@ -66,10 +66,7 @@ impl Eq for JobStatus {}
 
 impl JobStatus {
     fn is_gracefully_terminatable(&self) -> bool {
-        match *self {
-            JobStatus::Ready(Some(_)) => true,
-            _ => false,
-        }
+        matches!(*self, JobStatus::Ready(Some(_)))
     }
 }
 


### PR DESCRIPTION
Quick fix for the [newly added clippy warning](https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro).