### PR TITLE
👷 Implement basic integration test (K8s + Docker)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,223 @@
+name: 🔎 Integration tests
+
+on: [push]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-core:
+    name: 🔨 Build Core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            core/.cache
+          key: build-core-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build core in debug configuration
+        run: make core-debug
+      - name: Fix permission for cache
+        run: sudo chmod -R 777 core/.cache
+      - uses: actions/upload-artifact@v2
+        with:
+          name: core-documentation
+          path: .artifacts/core-documentation
+      - uses: actions/upload-artifact@v2
+        with:
+          name: core-executable
+          path: .artifacts/core-executable
+
+  build-api:
+    name: 🔨 Build API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: "14"
+      - run: make api
+      - uses: actions/upload-artifact@v2
+        with:
+          name: api-executable
+          path: .artifacts/api-executable
+
+  bundle-api:
+    name: 🐳 Push API to GHCR
+    runs-on: ubuntu-latest
+    needs: build-api
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: api-executable
+          path: .artifacts/api-executable
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=ghcr.io/tilblechschmidt/webgrid/api
+          TAGS="${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          echo "tags=${TAGS}" >> $GITHUB_ENV
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Build and push webgrid/api Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: distribution/docker/images/api/Dockerfile
+          tags: ${{ env.tags }}
+          push: true
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ env.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  bundle-core:
+    name: 🐳 Push Core to GHCR
+    runs-on: ubuntu-latest
+    needs: build-core
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: core-executable
+          path: .artifacts/core-executable
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=ghcr.io/tilblechschmidt/webgrid/core
+          TAGS="${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          echo "tags=${TAGS}" >> $GITHUB_ENV
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+          chmod +x .artifacts/core-executable/webgrid
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Build and push webgrid/core Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: distribution/docker/images/core/Dockerfile
+          tags: ${{ env.tags }}
+          push: true
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ env.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  bundle-node:
+    name: 🐳 Push Node to GHCR
+    runs-on: ubuntu-latest
+    needs: build-core
+    strategy:
+      matrix:
+        browser: ["chrome", "firefox"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: core-executable
+          path: .artifacts/core-executable
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=ghcr.io/tilblechschmidt/webgrid/node-${{ matrix.browser }}
+          TAGS="${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          echo "tags=${TAGS}" >> $GITHUB_ENV
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+          chmod +x .artifacts/core-executable/webgrid
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Build and push webgrid/node-${{ matrix.browser }} Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: distribution/docker/images/node/Dockerfile
+          build-args: browser=${{ matrix.browser }}
+          tags: ${{ env.tags }}
+          push: true
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ env.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  docker-integration:
+    name: 🐳 Docker integration test
+    runs-on: ubuntu-latest
+    needs:
+      - bundle-core
+      - bundle-node
+      - bundle-api
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Run integration test in Docker
+        run: |
+          export REPOSITORY=ghcr.io/tilblechschmidt/webgrid
+          export IMAGE_TAG="sha-${GITHUB_SHA::8}"
+          echo "Using $REPOSITORY/core:$IMAGE_TAG"
+
+          pip install selenium
+          docker pull $REPOSITORY/node-firefox:$IMAGE_TAG
+          docker pull $REPOSITORY/node-chrome:$IMAGE_TAG
+
+          make install
+          docker-compose -f distribution/docker/docker-compose.yml logs -f &
+          sleep 60
+          python3 test/integration.py 8080
+
+  kubernetes-integration:
+    name: ☸️ Kubernetes integration test
+    runs-on: ubuntu-latest
+    needs:
+      - bundle-core
+      - bundle-node
+      - bundle-api
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          curl -fLO https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64
+          chmod +x stern_linux_amd64
+          sudo mv stern_linux_amd64 /usr/local/bin/stern
+
+          pip install selenium
+      - name: Start K8s cluster
+        run: |
+          curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=777 sh -
+          mkdir -p ~/.kube
+          cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+
+          kubectl cluster-info
+          kubectl get nodes
+      - name: Run integration test in K8s
+        run: |
+          kubectl create secret docker-registry regcred --docker-server=ghcr.io --docker-username=${{ github.repository_owner }} --docker-password=${{ secrets.GHCR_TOKEN }}
+          helm install test ./distribution/kubernetes/chart/ --set image.repository=ghcr.io/tilblechschmidt/webgrid,image.tag=sha-${GITHUB_SHA::8},image.pullSecret=regcred
+          kubectl apply -f test/node-port.yml
+          sleep 5
+          stern --color always test-webgrid* &
+          kubectl get pods
+          sleep 80
+          kubectl get pods
+          kubectl get services
+
+          python3 test/integration.py 30007

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -216,7 +216,7 @@ jobs:
           sleep 5
           stern --color always test-webgrid* &
           kubectl get pods
-          sleep 80
+          sleep 120
           kubectl get pods
           kubectl get services
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           key: build-core-${{ runner.os }}-lockfile=${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
-        run: make build-core
+        run: make core
 
       - name: Change cache permission
         run: sudo chmod -R 777 core/.cache
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: "14"
 
-      - run: make build-api
+      - run: make api
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           node-version: "14"
 
-      - run: make build-api
+      - run: make api
 
   docs:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 bundle: bundle-api bundle-core bundle-node
 build: build-api build-core
+build-debug: build-api build-core-debug
+all: build bundle
 
 build-api:
 	cd api && yarn install && yarn build
@@ -9,6 +11,9 @@ build-api:
 	mv api/dist/index.js .artifacts/api-executable
 
 build-core:
+	cd core && ./build.sh --release
+
+build-core-debug:
 	cd core && ./build.sh
 
 bundle-api: build-api
@@ -26,7 +31,7 @@ clean:
 	rm -rf core/.cache core/target
 	rm -rf api/dist api/node_modules api/src/generated.ts
 
-install: bundle
+install:
 	-docker network create webgrid
 	-docker volume create webgrid
 	docker-compose -f distribution/docker/docker-compose.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ build: api core
 build-debug: api core-debug
 all: build bundle
 
+builder:
+	# The source image is manually built from the TilBlechschmidt/rust-musl-builder repository
+	docker build --platform linux/arm64 --build-arg TAG=arm64 -f distribution/docker/images/builder/Dockerfile -t webgrid/rust-musl-builder:arm64-root .
+	docker build --platform linux/amd64 --build-arg TAG=amd64 -f distribution/docker/images/builder/Dockerfile -t webgrid/rust-musl-builder:amd64-root .
+
 api:
 	cd api && yarn install && yarn build
 	mkdir -p .artifacts/api-executable

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,28 @@
-.PHONY: build-core build-api clean
+.PHONY: core api clean
 
 bundle: bundle-api bundle-core bundle-node
-build: build-api build-core
-build-debug: build-api build-core-debug
+build: api core
+build-debug: api core-debug
 all: build bundle
 
-build-api:
+api:
 	cd api && yarn install && yarn build
 	mkdir -p .artifacts/api-executable
 	mv api/dist/index.js .artifacts/api-executable
 
-build-core:
+core:
 	cd core && ./build.sh --release
 
-build-core-debug:
+core-debug:
 	cd core && ./build.sh
 
-bundle-api: build-api
+bundle-api: api
 	docker build --platform linux/amd64 -f distribution/docker/images/api/Dockerfile -t webgrid/api:latest .
 
-bundle-core: build-core
+bundle-core: core
 	docker build --platform linux/amd64 -f distribution/docker/images/core/Dockerfile -t webgrid/core:latest .
 
-bundle-node: build-core
+bundle-node: core
 	docker build --platform linux/amd64 -f distribution/docker/images/node/Dockerfile -t webgrid/node-firefox:latest --build-arg browser=firefox .
 	docker build --platform linux/amd64 -f distribution/docker/images/node/Dockerfile -t webgrid/node-chrome:latest --build-arg browser=chrome .
 

--- a/core/build.sh
+++ b/core/build.sh
@@ -5,6 +5,16 @@ TARGET_DIR=$(pwd)/../.artifacts
 
 set -e
 
+if [[ $1 = "--release" ]];
+then
+	echo "Building in release configuration"
+	RELEASE_FLAG="--release"
+	BUILD_OUTPUT_DIR="release"
+else
+	echo "Building in debug configuration"
+	BUILD_OUTPUT_DIR="debug"
+fi
+
 echo "Creating cache directories in $BUILD_DIR"
 mkdir -p $BUILD_DIR
 mkdir -p $BUILD_DIR/project
@@ -29,7 +39,7 @@ docker run --rm --name core-build \
 	-v "$BUILD_DIR/target":/home/rust/src/target \
 	-e CARGO_TERM_COLOR=always \
 	webgrid/rust-musl-builder \
-	bash -c "cargo build --release --locked && cargo doc --release --locked --no-deps && rm /home/rust/src/target/x86_64-unknown-linux-musl/doc/.lock"
+	bash -c "cargo build ${RELEASE_FLAG} --locked && cargo doc ${RELEASE_FLAG} --locked --no-deps && rm /home/rust/src/target/x86_64-unknown-linux-musl/doc/.lock"
 
 # TODO: Strip debug symbols from binary
 
@@ -40,4 +50,4 @@ mkdir -p $TARGET_DIR/core-executable
 echo "Copying documentation to output"
 rsync -a --progress $BUILD_DIR/target/x86_64-unknown-linux-musl/doc $TARGET_DIR/core-documentation
 echo "Copying executable to output"
-rsync -av --progress $BUILD_DIR/target/x86_64-unknown-linux-musl/release/webgrid $TARGET_DIR/core-executable
+rsync -av --progress $BUILD_DIR/target/x86_64-unknown-linux-musl/$BUILD_OUTPUT_DIR/webgrid $TARGET_DIR/core-executable

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   proxy:
-    image: webgrid/core:latest
+    image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-proxy
     command: proxy --log debug,hyper=warn
@@ -10,28 +10,28 @@ services:
     depends_on:
       - redis
   manager:
-    image: webgrid/core:latest
+    image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-manager
     command: manager example-manager webgrid-manager --log debug,hyper=warn
     depends_on:
       - redis
   orchestrator:
-    image: webgrid/core:latest
+    image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-orchestrator
-    command: orchestrator --slot-count 5 example-orchestrator docker --images "webgrid/node-firefox:latest=firefox::68.7.0esr,webgrid/node-chrome:latest=chrome::81.0.4044.122" --log debug,hyper=warn
+    command: orchestrator --slot-count 5 example-orchestrator docker --images "${REPOSITORY:-webgrid}/node-firefox:${IMAGE_TAG:-latest}=firefox::68.7.0esr,${REPOSITORY:-webgrid}/node-chrome:${IMAGE_TAG:-latest}=chrome::81.0.4044.122" --log debug,hyper=warn
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   storage:
-    image: webgrid/core:latest
+    image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-storage
     command: storage --log debug,hyper=warn --host webgrid-storage --storage-directory /storage --size-limit 10
     volumes:
       - webgrid:/storage
   api:
-    image: webgrid/api:latest
+    image: ${REPOSITORY:-webgrid}/api:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-api
     environment:

--- a/distribution/docker/images/builder/Dockerfile
+++ b/distribution/docker/images/builder/Dockerfile
@@ -1,0 +1,5 @@
+ARG TAG=amd64
+FROM webgrid/rust-musl-builder:$TAG
+
+USER root
+ENV HOME=/home/rust

--- a/distribution/kubernetes/chart/templates/_helpers.tpl
+++ b/distribution/kubernetes/chart/templates/_helpers.tpl
@@ -82,3 +82,10 @@ Create the name of the persistent volume claim to use
 {{- default "default" .Values.recording.persistentVolumeClaim.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Allow customization of the image tag used
+*/}}
+{{- define "web-grid.imageTag" -}}
+{{- default .Chart.AppVersion .Values.image.tag }}
+{{- end }}

--- a/distribution/kubernetes/chart/templates/api.yaml
+++ b/distribution/kubernetes/chart/templates/api.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: "{{ .Values.image.repository }}/api:{{ .Chart.AppVersion }}"
+        - image: "{{ .Values.image.repository }}/api:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Chart.Name }}-api
           ports:

--- a/distribution/kubernetes/chart/templates/api.yaml
+++ b/distribution/kubernetes/chart/templates/api.yaml
@@ -29,6 +29,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - image: "{{ .Values.image.repository }}/api:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/distribution/kubernetes/chart/templates/manager.yaml
+++ b/distribution/kubernetes/chart/templates/manager.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: "{{ .Values.image.repository }}/core:{{ .Chart.AppVersion }}"
+        - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Chart.Name }}-manager
           args: ["manager", "--status-server"]

--- a/distribution/kubernetes/chart/templates/manager.yaml
+++ b/distribution/kubernetes/chart/templates/manager.yaml
@@ -29,6 +29,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/distribution/kubernetes/chart/templates/metrics.yaml
+++ b/distribution/kubernetes/chart/templates/metrics.yaml
@@ -32,6 +32,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/distribution/kubernetes/chart/templates/metrics.yaml
+++ b/distribution/kubernetes/chart/templates/metrics.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: "{{ .Values.image.repository }}/core:{{ .Chart.AppVersion }}"
+        - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Chart.Name }}-metrics
           args: ["metrics", "--status-server"]

--- a/distribution/kubernetes/chart/templates/orchestrator.yaml
+++ b/distribution/kubernetes/chart/templates/orchestrator.yaml
@@ -34,6 +34,10 @@ spec:
         - name: orchestrator-config
           configMap:
             name: {{ include "web-grid.fullname" . }}-orchestrator
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/distribution/kubernetes/chart/templates/orchestrator.yaml
+++ b/distribution/kubernetes/chart/templates/orchestrator.yaml
@@ -35,7 +35,7 @@ spec:
           configMap:
             name: {{ include "web-grid.fullname" . }}-orchestrator
       containers:
-        - image: "{{ .Values.image.repository }}/core:{{ .Chart.AppVersion }}"
+        - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Chart.Name }}-orchestrator
           args: ["orchestrator", "kubernetes", "--status-server"]
@@ -56,7 +56,7 @@ spec:
             - name: SLOT_COUNT
               value: "{{ .Values.maxSessionsPerOrchestrator }}"
             - name: IMAGES
-              value: "{{ .Values.image.repository }}/node-firefox:{{ .Chart.AppVersion }}=firefox::68.7.0esr,{{ .Values.image.repository }}/node-chrome:{{ .Chart.AppVersion }}=chrome::81.0.4044.122"
+              value: "{{ .Values.image.repository }}/node-firefox:{{ include "web-grid.imageTag" . }}=firefox::68.7.0esr,{{ .Values.image.repository }}/node-chrome:{{ include "web-grid.imageTag" . }}=chrome::81.0.4044.122"
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
             - name: WEBGRID_CONFIG_DIR

--- a/distribution/kubernetes/chart/templates/proxy.yaml
+++ b/distribution/kubernetes/chart/templates/proxy.yaml
@@ -29,6 +29,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/distribution/kubernetes/chart/templates/proxy.yaml
+++ b/distribution/kubernetes/chart/templates/proxy.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: "{{ .Values.image.repository }}/core:{{ .Chart.AppVersion }}"
+        - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Chart.Name }}-proxy
           args: ["proxy", "--status-server"]

--- a/distribution/kubernetes/chart/templates/storage.yaml
+++ b/distribution/kubernetes/chart/templates/storage.yaml
@@ -50,6 +50,10 @@ spec:
         - name: storage
           persistentVolumeClaim:
             claimName: {{ include "web-grid.recordingPVCName" . }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/distribution/kubernetes/chart/templates/storage.yaml
+++ b/distribution/kubernetes/chart/templates/storage.yaml
@@ -51,7 +51,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "web-grid.recordingPVCName" . }}
       containers:
-        - image: "{{ .Values.image.repository }}/core:{{ .Chart.AppVersion }}"
+        - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Chart.Name }}-storage
           args: ["storage", "--status-server"]

--- a/distribution/kubernetes/chart/values.yaml
+++ b/distribution/kubernetes/chart/values.yaml
@@ -37,6 +37,7 @@ image:
   # Defaults to Chart.AppVersion if not set
   tag: ""
   pullPolicy: Always
+  pullSecret: ""
 
 serviceAccount:
   # Specifies whether a service account with RBAC should be created

--- a/distribution/kubernetes/chart/values.yaml
+++ b/distribution/kubernetes/chart/values.yaml
@@ -34,6 +34,8 @@ replicaCount:
 
 image:
   repository: webgrid
+  # Defaults to Chart.AppVersion if not set
+  tag: ""
   pullPolicy: Always
 
 serviceAccount:

--- a/docs/features/screen-recording.md
+++ b/docs/features/screen-recording.md
@@ -15,7 +15,7 @@ In order to view or embed a video you need to retrieve its unique session identi
     WebDriver driver = new RemoteWebDriver(new URL("http://localhost:8080"), firefoxOptions);
     driver.get("http://dcuk.com");
 
-    SessionId session = ((FirefoxDriver) driver).getSessionId();
+    SessionId session = ((RemoteWebDriver) driver).getSessionId();
     System.out.println("Session id: " + session.toString());
 
     System.in.read();

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -22,7 +22,7 @@ def copy_docker_compose(site_dir):
     git_ref = os.getenv('GITHUB_REF')
     if git_ref is not None and git_ref.startswith('refs/tags/'):
         version = git_ref[10:]
-        filedata = filedata.replace(':latest', ':' + version)
+        filedata = filedata.replace(':-latest', ':-' + version)
         print("Overwriting docker-compose version with git tag '" + version + "'")
 
     # Write the file out again

--- a/test/integration.py
+++ b/test/integration.py
@@ -1,0 +1,38 @@
+from selenium import webdriver
+from selenium.webdriver.support.ui import WebDriverWait as wait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+from time import sleep
+import sys
+
+if len(sys.argv) < 2:
+    sys.exit("No port provided (first cli argument)!")
+
+port = sys.argv[1]
+url = "http://127.0.0.1:" + port
+print("Connecting to: " + url)
+browser = webdriver.Remote(url)
+
+print("Session id: " + browser.session_id)
+
+browser.get('https://duckduckgo.com')
+search_form = browser.find_element_by_id('search_form_input_homepage')
+search_form.send_keys('webgrid.dev')
+search_form.submit()
+
+wait(browser, 10).until(EC.presence_of_element_located((By.CLASS_NAME, 'result__a')))
+
+results = browser.find_elements_by_class_name('result__a')
+
+found = False
+for result in results:
+    found = result.text.find("WebGrid") > -1
+    if found:
+        break
+
+browser.quit()
+
+if not found:
+    sys.exit("Did not find WebGrid in the search results :(")
+else:
+    print("Test successful!")

--- a/test/node-port.yml
+++ b/test/node-port.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-webgrid-nodeport
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: http
+      nodePort: 30007
+      protocol: TCP
+      name: http
+  selector:
+    web-grid/component: proxy
+    app.kubernetes.io/name: webgrid
+    app.kubernetes.io/instance: test


### PR DESCRIPTION
### 🔧 Changes
This PR adds a basic GitHub Actions workflow for running the WebGrid in both Docker and K8s and throwing a simple integration test (located in the `/test` folder of the repository) at it.

Solving #4 would add additional speed benefits 😉 

As a side effect, this PR also adds the ability to use `imagePullSecrets` with the Helm chart and finalises support for building on ARM CPUs. Additionally, it makes image tags and repositories configurable for both the Helm chart and docker-compose file. It also enables debug builds of the docker containers to speed up the development process!