### PR TITLE
Add metadata support to requested capabilities

### DIFF
--- a/api/src/resolvers/query.ts
+++ b/api/src/resolvers/query.ts
@@ -3,15 +3,36 @@ export default {
         .then(ids => ids.map(id => ({ id }))),
 
 
-    sessions: async (_, { state }, { redis }) => {
+    sessions: async (_, { state, name, build }, { redis }) => {
+        let sessionIDs = []
+
         if (state) {
             const key = state === 'Active' ? 'sessions.active' : 'sessions.terminated'
-            return await redis.smembers(key).then(ids => ids.map(id => ({id})))
+            sessionIDs = await redis.smembers(key)
         } else {
             const active = await redis.smembers('sessions.active')
             const terminated = await redis.smembers('sessions.terminated')
-            return [...active, ...terminated].map(id => ({id}))
+            sessionIDs = [...active, ...terminated]
         }
+
+        // Filter by name/build if applicable
+        if (name || build) {
+            let filteredSessionIDs = []
+
+            for (const sessionID of sessionIDs) {
+                const metadata = (await redis.hgetall(`session:${sessionID}:metadata`)) || {}
+                let nameMatches = !name || name == metadata.name
+                let buildMatches = !build || build == metadata.build
+
+                if (nameMatches && buildMatches) {
+                    filteredSessionIDs.push(sessionID)
+                }
+            }
+
+            sessionIDs = filteredSessionIDs
+        }
+
+        return sessionIDs.map(id => ({ id }))
     },
 
     session: (_, { id }) => ({ id }),

--- a/api/src/resolvers/session.ts
+++ b/api/src/resolvers/session.ts
@@ -6,6 +6,7 @@ export default {
 
     status: ({ id }, _, { redis }) => redis.hgetall(`session:${id}:status`),
     capabilities: ({ id }, _, { redis }) => redis.hgetall(`session:${id}:capabilities`),
+    metadata: ({ id }, _, { redis }) => redis.hgetall(`session:${id}:metadata`),
 
     upstream: ({ id }, _, { redis }) => redis.hgetall(`session:${id}:upstream`),
     downstream: ({ id }, _, { redis }) => redis.hgetall(`session:${id}:downstream`),

--- a/api/src/schema/query.ts
+++ b/api/src/schema/query.ts
@@ -7,7 +7,7 @@ enum SessionState {
 }
 
 type Query {
-    sessions(state: SessionState): [Session!]!
+    sessions(state: SessionState, name: String, build: String): [Session!]!
     orchestrators: [Orchestrator!]!
 
     session(id: String!): Session

--- a/api/src/schema/session.ts
+++ b/api/src/schema/session.ts
@@ -27,6 +27,11 @@ type SessionDownstream {
     lastSeen: Date
 }
 
+type SessionMetadata {
+    name: String
+    build: String
+}
+
 type Session {
     id: String!
     alive: Boolean
@@ -36,6 +41,7 @@ type Session {
 
     status: SessionStatusTransitions
     capabilities: SessionCapabilities
+    metadata: SessionMetadata
 
     upstream: SessionUpstream
     downstream: SessionDownstream

--- a/core/src/libraries/helpers/capabilities.rs
+++ b/core/src/libraries/helpers/capabilities.rs
@@ -99,7 +99,12 @@ pub struct Capabilities {
     /// Describes the current session’s user prompt handler.
     pub unhandled_prompt_behavior: Option<CapabilityUnhandledPromptBehavior>,
 
-    /// Additional capabilities that are not part of the W3C standard
+    /// Name for a session for later querying
+    pub name: Option<String>,
+    /// Build for a session for later querying
+    pub build: Option<String>,
+
+    /// Additional capabilities that are not part of the W3C standard or added by WebGrid
     #[serde(flatten)]
     pub extension_capabilities: HashMap<String, Value>,
 }
@@ -141,6 +146,9 @@ impl Capabilities {
             timeouts: None,
             unhandled_prompt_behavior: None,
 
+            name: None,
+            build: None,
+
             extension_capabilities: HashMap::new(),
         }
     }
@@ -166,6 +174,9 @@ impl Capabilities {
                 .unhandled_prompt_behavior
                 .clone()
                 .xor(other.unhandled_prompt_behavior),
+
+            name: self.name.clone().xor(other.name),
+            build: self.build.clone().xor(other.build),
 
             // TODO Merge the extension capabilities
             extension_capabilities: self.extension_capabilities.clone(),

--- a/core/src/libraries/helpers/keys.rs
+++ b/core/src/libraries/helpers/keys.rs
@@ -110,6 +110,10 @@ pub mod session {
         format!("{}:capabilities", session_prefix(session_id))
     }
 
+    pub fn metadata(session_id: &str) -> String {
+        format!("{}:metadata", session_prefix(session_id))
+    }
+
     pub fn upstream(session_id: &str) -> String {
         format!("{}:upstream", session_prefix(session_id))
     }

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -63,6 +63,11 @@ All metadata is stored in a key-value in-memory database called [Redis](https://
 	actual = string                                 // JSON
 }
 
+`session:${ID}:metadata` = Hashes {
+	name = string
+	build = string
+}
+
 `session:${ID}:upstream` = Hashes {
 	host = string
 	port = number

--- a/docs/features/api.md
+++ b/docs/features/api.md
@@ -8,3 +8,30 @@ http://<your-webgrid-address>/api
 
 !!! tip
     When opening the API in a browser, a GraphQL Playground opens up which provides syntax highlighting, code completion and a complete documentation!
+
+## Session metadata
+
+When creating a session, you can attach additional metadata which you can later use to query for your session. To do so, set one or both of the following keys in your client libraries `DesiredCapabilities` object.
+
+=== "Java"
+    ```java
+    DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
+    ...
+    desiredCapabilities.setCapability("name", "your-cool-session-name");
+    desiredCapabilities.setCapability("build", "your-build-identifier");
+    ...
+    ```
+
+To query session objects which match your name, use a query like this:
+
+```javascript
+query {
+  sessions(name: "test-name") {
+    id
+    metadata {
+      name
+      build
+    }
+  }
+}
+```

--- a/docs/features/screen-recording.md
+++ b/docs/features/screen-recording.md
@@ -53,7 +53,7 @@ In order to view or embed a video you need to retrieve its unique session identi
     }
     ```
 
-    It returns you a list of all sessions with their corresponding identifiers and whether or not they are currently alive.
+    It returns you a list of all sessions with their corresponding identifiers and whether or not they are currently alive. To identify your session uniquely using metadata, head over to the [API documentation](./api.md#session-metadata).
 
 ## Embedding
 


### PR DESCRIPTION
### 🔧 Changes
This PR adds support for the `name` and `build` fields in the requested `Capabilities` object. These match the [metadata fields supported by Zalenium](https://opensource.zalando.com/zalenium/#usage) for compatibility. These fields allow it to more easily find a session when the ID is not available.

It adds additional query parameters to the `sessions` query to filter the output.