### PR TITLE
Implement active garbage collection for DB

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,7 +42,8 @@ sqlx = { version = "0.5", default-features = false, features = [ "macros", "sqli
 tokio = { version = "1.2", features = ["full"] }
 
 [features]
-default = ["proxy", "manager", "node", "metrics", "storage", "docker", "kubernetes"]
+default = ["gc", "proxy", "manager", "node", "metrics", "storage", "docker", "kubernetes"]
+gc = []
 proxy = []
 manager = []
 node = []

--- a/core/src/libraries/helpers/keys.rs
+++ b/core/src/libraries/helpers/keys.rs
@@ -44,6 +44,10 @@ pub mod orchestrator {
         format!("{}:heartbeat", orchestrator_prefix(orchestrator_id))
     }
 
+    pub fn retain(orchestrator_id: &str) -> String {
+        format!("{}:retain", orchestrator_prefix(orchestrator_id))
+    }
+
     pub mod capabilities {
         use super::orchestrator_prefix;
 

--- a/core/src/libraries/helpers/lua.rs
+++ b/core/src/libraries/helpers/lua.rs
@@ -7,16 +7,22 @@
 /// Returns the associated slot, moves it to the terminated state and removed the heartbeat.
 /// The following variables have to be defined for the script to work:
 /// - sessionID
-/// - orchestrator
 /// - currentTime
+///
+/// If the following variable is set, the sessions slot will be returned to the given orchestrator:
+/// - orchestrator
 ///
 /// These variables are being defined by the script:
 /// - slot
 pub fn terminate_session() -> String {
     r"
-    local slot = redis.call('get', 'session:' .. sessionID .. ':slot')
-    redis.call('DEL', 'session:' .. sessionID .. ':slot')
-    redis.call('RPUSH', 'orchestrator:' .. orchestrator .. ':slots.reclaimed', slot)
+    local slot = redis.call('GETDEL', 'session:' .. sessionID .. ':slot')
+    
+    if ( orchestrator and slot )
+    then
+        redis.call('RPUSH', 'orchestrator:' .. orchestrator .. ':slots.reclaimed', slot)
+    end
+
     redis.call('SMOVE', 'sessions.active', 'sessions.terminated', sessionID)
     redis.call('HSET', 'session:'  .. sessionID .. ':status', 'terminatedAt', currentTime)
     redis.call('EXPIRE', 'session:' .. sessionID .. ':heartbeat.node', 1)
@@ -31,4 +37,57 @@ pub fn fetch_orchestrator_from_session() -> String {
     // Variables that are being defined:
     // orchestrator
     r"local orchestrator = redis.call('rpoplpush', 'session:' .. sessionID .. ':orchestrator', 'session:' .. sessionID .. ':orchestrator')".to_string()
+}
+
+/// Purges a session object and all related keys from the database
+///
+/// Takes the session ID as its first argument.
+pub fn delete_session() -> String {
+    r"
+    local sessionID = ARGV[1];
+    redis.call('SREM', 'sessions.active', sessionID)
+    redis.call('SREM', 'sessions.terminated', sessionID)
+    
+    redis.call('DEL', 'session:' .. sessionID .. ':heartbeat.node')
+    redis.call('DEL', 'session:' .. sessionID .. ':heartbeat.manager')
+    
+    redis.call('DEL', 'session:' .. sessionID .. ':slot')
+    redis.call('DEL', 'session:' .. sessionID .. ':orchestrator')
+    
+    redis.call('DEL', 'session:' .. sessionID .. ':log')
+    redis.call('DEL', 'session:' .. sessionID .. ':status')
+    redis.call('DEL', 'session:' .. sessionID .. ':capabilities')
+    
+    redis.call('DEL', 'session:' .. sessionID .. ':upstream')
+    redis.call('DEL', 'session:' .. sessionID .. ':downstream')
+    
+    redis.call('DEL', 'session:' .. sessionID .. ':storage')
+    "
+    .to_string()
+}
+
+/// Purges an orchestrator object and all related keys from the database
+///
+/// Takes the orchestrator ID as its first argument.
+pub fn delete_orchestrator() -> String {
+    r"
+    local orchestratorID = ARGV[1];
+    
+    redis.call('SREM', 'orchestrators', orchestratorID)
+    redis.call('DEL', 'orchestrator:' .. orchestratorID)
+    
+    redis.call('DEL', 'orchestrator:' .. orchestratorID .. ':heartbeat')
+    redis.call('DEL', 'orchestrator:' .. orchestratorID .. ':retain')
+    
+    redis.call('DEL', 'orchestrator:' .. orchestratorID .. ':capabilities:platformName')
+    redis.call('DEL', 'orchestrator:' .. orchestratorID .. ':capabilities:browsers')
+    
+    redis.call('DEL', 'orchestrator:' .. orchestratorID .. ':slots.reclaimed')
+    redis.call('DEL', 'orchestrator:' .. orchestratorID .. ':slots.available')
+    redis.call('DEL', 'orchestrator:' .. orchestratorID .. ':slots')
+
+    redis.call('DEL', 'orchestrator:' .. orchestratorID .. ':backlog')
+    redis.call('DEL', 'orchestrator:' .. orchestratorID .. ':pending')
+    "
+    .to_string()
 }

--- a/core/src/libraries/helpers/timeout.rs
+++ b/core/src/libraries/helpers/timeout.rs
@@ -35,12 +35,12 @@ impl Timeout {
     fn default(&self) -> usize {
         match *self {
             // Manager
-            Timeout::Queue => 120,
+            Timeout::Queue => 600,
             Timeout::Scheduling => 60,
-            Timeout::NodeStartup => 45,
+            Timeout::NodeStartup => 120,
             // Node
             Timeout::DriverStartup => 30,
-            Timeout::SessionTermination => 60,
+            Timeout::SessionTermination => 900,
             // Orchestrator
             Timeout::SlotReclaimInterval => 300,
         }

--- a/core/src/libraries/lifecycle/mod.rs
+++ b/core/src/libraries/lifecycle/mod.rs
@@ -4,5 +4,5 @@ mod heart;
 mod heart_beat;
 pub mod logging;
 
-pub use heart::{Heart, HeartStone};
+pub use heart::{DeathReason, Heart, HeartStone};
 pub use heart_beat::{BeatValue, HeartBeat};

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -34,6 +34,9 @@ enum Command {
 
     #[cfg(feature = "orchestrator")]
     Orchestrator(orchestrator::Options),
+
+    #[cfg(feature = "gc")]
+    GC(gc::Options),
 }
 
 #[tokio::main]
@@ -73,6 +76,9 @@ async fn main() -> Result<()> {
                 provisioners::kubernetes::run(shared_options, core_options.core, options).await
             }
         },
+
+        #[cfg(feature = "gc")]
+        Command::GC(options) => gc::run(shared_options, options).await?,
     }
 
     Ok(())

--- a/core/src/services/gc/context.rs
+++ b/core/src/services/gc/context.rs
@@ -1,0 +1,14 @@
+use crate::libraries::resources::DefaultResourceManager;
+
+#[derive(Clone)]
+pub struct Context {
+    pub resource_manager: DefaultResourceManager,
+}
+
+impl Context {
+    pub fn new(redis_url: String) -> Self {
+        Self {
+            resource_manager: DefaultResourceManager::new(redis_url),
+        }
+    }
+}

--- a/core/src/services/gc/jobs/garbage_collector.rs
+++ b/core/src/services/gc/jobs/garbage_collector.rs
@@ -1,0 +1,175 @@
+use super::super::Context;
+use crate::libraries::{
+    helpers::{keys, lua},
+    resources::ResourceManager,
+    scheduling::{Job, TaskManager},
+};
+use crate::with_shared_redis_resource;
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::Utc;
+use log::{debug, info, warn};
+use redis::{AsyncCommands, Script};
+use std::time::Duration;
+use tokio::time::interval;
+
+#[derive(Clone)]
+pub struct GarbageCollectorJob {
+    session_retention_duration: chrono::Duration,
+}
+
+#[async_trait]
+impl Job for GarbageCollectorJob {
+    type Context = Context;
+
+    const NAME: &'static str = module_path!();
+
+    async fn execute(&self, manager: TaskManager<Self::Context>) -> Result<()> {
+        manager.ready().await;
+
+        let mut interval = interval(Duration::from_secs(600));
+
+        loop {
+            interval.tick().await;
+            debug!("Running garbage collector cycle");
+
+            let terminated_count = self.terminate_dead_sessions(manager.clone()).await?;
+            let purged_count = self.purge_old_sessions(manager.clone()).await?;
+
+            info!(
+                "Terminated {} and purged {} sessions",
+                terminated_count, purged_count
+            );
+
+            let purged_orchestrator_count = self.purge_old_orchestrators(manager.clone()).await?;
+            info!("Purged {} orchestrators", purged_orchestrator_count);
+        }
+    }
+}
+
+impl GarbageCollectorJob {
+    pub fn new(session_retention_duration: i64) -> Self {
+        Self {
+            session_retention_duration: chrono::Duration::seconds(session_retention_duration),
+        }
+    }
+
+    async fn terminate_dead_sessions(&self, manager: TaskManager<Context>) -> Result<usize> {
+        // Fetch active sessions
+        let mut con = with_shared_redis_resource!(manager);
+        let active_sessions: Vec<String> = con.smembers(&*keys::session::LIST_ACTIVE).await?;
+
+        // Preload the session termination script
+        let script_content = format!(
+            r#"
+            local sessionID = ARGV[1];
+            local currentTime = ARGV[2];
+            {loadOrchestratorID}
+            {terminateSession}
+        "#,
+            loadOrchestratorID = lua::fetch_orchestrator_from_session(),
+            terminateSession = lua::terminate_session(),
+        );
+        let termination_script = Script::new(&script_content);
+
+        let mut terminated_count = 0;
+        for session_id in active_sessions.into_iter() {
+            let has_manager_heartbeat: bool = con
+                .exists(keys::session::heartbeat::manager(&session_id))
+                .await?;
+
+            let has_node_heartbeat: bool = con
+                .exists(keys::session::heartbeat::node(&session_id))
+                .await?;
+
+            // If the session has no heartbeat / responsible operator, it is dead.
+            if !(has_manager_heartbeat || has_node_heartbeat) {
+                debug!("Terminating dead session: {}", session_id);
+                terminated_count += 1;
+
+                if let Err(e) = termination_script
+                    .arg(&session_id)
+                    .arg(Utc::now().to_rfc3339())
+                    .invoke_async::<_, ()>(&mut con)
+                    .await
+                {
+                    warn!("Failed to terminate dead session {}: {}", session_id, e);
+                }
+            }
+        }
+
+        Ok(terminated_count)
+    }
+
+    async fn purge_old_sessions(&self, manager: TaskManager<Context>) -> Result<usize> {
+        // Fetch terminated sessions
+        let mut con = with_shared_redis_resource!(manager);
+        let terminated_sessions: Vec<String> =
+            con.smembers(&*keys::session::LIST_TERMINATED).await?;
+
+        // Preload the deletion script
+        let deletion_script = Script::new(&lua::delete_session());
+
+        // Go through all terminated sessions
+        let mut purged_count = 0;
+        for session_id in terminated_sessions.into_iter() {
+            // Determine its age (since termination)
+            let termination_time: String = con
+                .hget(keys::session::status(&session_id), "terminatedAt")
+                .await?;
+
+            let parsed_termination_time = chrono::DateTime::parse_from_rfc3339(&termination_time)?;
+            let age = Utc::now().signed_duration_since(parsed_termination_time);
+
+            // If we crossed the threshold, purge it!
+            if age > self.session_retention_duration {
+                debug!("Purging old session: {}", session_id);
+                purged_count += 1;
+
+                if let Err(e) = deletion_script
+                    .arg(&session_id)
+                    .invoke_async::<_, ()>(&mut con)
+                    .await
+                {
+                    warn!("Failed to purge old session {}: {}", session_id, e);
+                }
+            }
+        }
+
+        Ok(purged_count)
+    }
+
+    async fn purge_old_orchestrators(&self, manager: TaskManager<Context>) -> Result<usize> {
+        // Fetch orchestrators
+        let mut con = with_shared_redis_resource!(manager);
+        let orchestrators: Vec<String> = con.smembers(&*keys::orchestrator::LIST).await?;
+
+        let deletion_script = Script::new(&lua::delete_orchestrator());
+
+        let mut purged_count = 0;
+        for orchestrator_id in orchestrators.into_iter() {
+            if let Ok(retain) = con
+                .exists::<_, bool>(keys::orchestrator::retain(&orchestrator_id))
+                .await
+            {
+                // If the retain key does not exist, purge the associated orchestrator
+                if !retain {
+                    purged_count += 1;
+
+                    if let Err(e) = deletion_script
+                        .arg(&orchestrator_id)
+                        .invoke_async::<_, ()>(&mut con)
+                        .await
+                    {
+                        warn!(
+                            "Failed to purge old orchestrator {}: {}",
+                            orchestrator_id, e
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(purged_count)
+    }
+}

--- a/core/src/services/gc/jobs/mod.rs
+++ b/core/src/services/gc/jobs/mod.rs
@@ -1,0 +1,3 @@
+mod garbage_collector;
+
+pub use garbage_collector::GarbageCollectorJob;

--- a/core/src/services/gc/mod.rs
+++ b/core/src/services/gc/mod.rs
@@ -1,0 +1,47 @@
+//! Garbage collector service
+
+use super::SharedOptions;
+use crate::libraries::lifecycle::Heart;
+use crate::libraries::scheduling::{JobScheduler, StatusServer};
+use crate::schedule;
+use anyhow::Result;
+use log::info;
+use structopt::StructOpt;
+
+mod context;
+mod jobs;
+
+use context::Context;
+use jobs::GarbageCollectorJob;
+
+#[derive(Debug, StructOpt)]
+/// Garbage collector service
+///
+/// Purges old or orphaned data from the database.
+pub struct Options {
+    /// Duration in seconds to retain a terminated session's metadata
+    #[structopt(short, long, default_value = "604800")]
+    session_retention_duration: i64,
+}
+
+pub async fn run(shared_options: SharedOptions, options: Options) -> Result<()> {
+    let (mut heart, _) = Heart::new();
+
+    let context = Context::new(shared_options.redis);
+    let scheduler = JobScheduler::default();
+
+    let status_job = StatusServer::new(&scheduler, shared_options.status_server);
+    let gc_job = GarbageCollectorJob::new(options.session_retention_duration);
+
+    schedule!(scheduler, context, {
+        status_job,
+        gc_job
+    });
+
+    let death_reason = heart.death().await;
+    info!("Heart died: {}", death_reason);
+
+    scheduler.terminate_jobs().await;
+
+    Ok(())
+}

--- a/core/src/services/mod.rs
+++ b/core/src/services/mod.rs
@@ -1,5 +1,8 @@
 //! Individual micro-services for the grid
 
+#[cfg(feature = "gc")]
+pub mod gc;
+
 #[cfg(feature = "proxy")]
 pub mod proxy;
 

--- a/core/src/services/node/tasks/log_exit.rs
+++ b/core/src/services/node/tasks/log_exit.rs
@@ -1,0 +1,33 @@
+use std::pin::Pin;
+
+use super::super::{structs::NodeError, Context};
+use crate::libraries::lifecycle::logging::{LogCode, SessionLogger};
+use crate::libraries::lifecycle::DeathReason;
+use crate::libraries::resources::ResourceManager;
+use crate::libraries::scheduling::TaskManager;
+use crate::with_shared_redis_resource;
+use futures::Future;
+
+pub fn log_exit(
+    death_reason: DeathReason,
+) -> impl Fn(TaskManager<Context>) -> Pin<Box<dyn Future<Output = Result<(), NodeError>> + Send>> {
+    move |manager: TaskManager<Context>| {
+        let death_reason = death_reason.clone();
+
+        Box::pin(async move {
+            let con = with_shared_redis_resource!(manager);
+            let mut logger =
+                SessionLogger::new(con, "node".to_string(), manager.context.id.to_owned());
+
+            let log_code = match death_reason {
+                DeathReason::LifetimeExceeded => LogCode::STIMEOUT,
+                DeathReason::Terminated => LogCode::CLOSED,
+                DeathReason::Killed(_) => LogCode::CLOSED,
+            };
+
+            logger.log(log_code, None).await.ok();
+
+            Ok(())
+        })
+    }
+}

--- a/core/src/services/node/tasks/mod.rs
+++ b/core/src/services/node/tasks/mod.rs
@@ -1,9 +1,11 @@
 mod driver;
 mod init_service;
 mod init_session;
+mod log_exit;
 mod terminate;
 
 pub use driver::{start_driver, stop_driver, DriverReference};
 pub use init_service::initialize_service;
 pub use init_session::initialize_session;
+pub use log_exit::log_exit;
 pub use terminate::terminate;

--- a/core/src/services/node/tasks/terminate.rs
+++ b/core/src/services/node/tasks/terminate.rs
@@ -1,13 +1,16 @@
 use super::super::{structs::NodeError, Context};
 use crate::libraries::helpers::lua;
+use crate::libraries::lifecycle::logging::{LogCode, SessionLogger};
 use crate::libraries::resources::ResourceManager;
 use crate::libraries::scheduling::TaskManager;
-use crate::with_redis_resource;
+use crate::with_shared_redis_resource;
 use chrono::offset::Utc;
 use redis::Script;
 
 pub async fn terminate(manager: TaskManager<Context>) -> Result<(), NodeError> {
-    let mut con = with_redis_resource!(manager);
+    let mut con = with_shared_redis_resource!(manager);
+    let log_con = with_shared_redis_resource!(manager);
+    let mut logger = SessionLogger::new(log_con, "node".to_string(), manager.context.id.to_owned());
 
     let script_content = format!(
         r#"
@@ -27,6 +30,8 @@ pub async fn terminate(manager: TaskManager<Context>) -> Result<(), NodeError> {
         .invoke_async(&mut con)
         .await
         .ok();
+
+    logger.log(LogCode::HALT, None).await.ok();
 
     Ok(())
 }

--- a/core/src/services/orchestrator/core/context.rs
+++ b/core/src/services/orchestrator/core/context.rs
@@ -34,6 +34,11 @@ impl Context {
         self.heart_beat
             .add_beat(&keys::orchestrator::heartbeat(&self.id), 60, 120)
             .await;
+
+        self.heart_beat
+            .add_beat(&keys::orchestrator::retain(&self.id), 300, 604_800)
+            .await;
+
         scheduler.spawn_job(self.heart_beat.clone(), self.resource_manager.clone());
     }
 }

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     platform: linux/amd64
     container_name: webgrid-orchestrator
     command: orchestrator --slot-count 5 example-orchestrator docker --images "${REPOSITORY:-webgrid}/node-firefox:${IMAGE_TAG:-latest}=firefox::68.7.0esr,${REPOSITORY:-webgrid}/node-chrome:${IMAGE_TAG:-latest}=chrome::81.0.4044.122" --log debug,hyper=warn
+    depends_on:
+      - redis
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   storage:
@@ -28,21 +30,31 @@ services:
     platform: linux/amd64
     container_name: webgrid-storage
     command: storage --log debug,hyper=warn --host webgrid-storage --storage-directory /storage --size-limit 10
+    depends_on:
+      - redis
     volumes:
       - webgrid:/storage
+  gc:
+    image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
+    platform: linux/amd64
+    container_name: webgrid-gc
+    command: gc --log debug
+    depends_on:
+      - redis
   api:
     image: ${REPOSITORY:-webgrid}/api:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-api
     environment:
       HOST: webgrid-api
+    depends_on:
+      - redis
   redis:
     image: redis:alpine
     container_name: webgrid-redis
     command: redis-server --notify-keyspace-events Kgx
     ports:
       - 6379:6379
-
 volumes:
   webgrid:
     external: true

--- a/distribution/kubernetes/chart/templates/redis.yaml
+++ b/distribution/kubernetes/chart/templates/redis.yaml
@@ -81,6 +81,26 @@ spec:
           name: redis-exporter
           ports:
             - containerPort: 9121
+        - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: {{ .Chart.Name }}-gc
+          args: ["gc", "--status-server"]
+          ports:
+            - name: status
+              containerPort: 47002
+              protocol: TCP
+          env:
+            - name: REDIS
+              value: "{{ include "web-grid.redisURL" . }}"
+            - name: RUST_LOG
+              value: {{ .Values.logLevel }}
+          livenessProbe:
+            tcpSocket:
+              port: status
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: status
 ---
 apiVersion: v1
 kind: Service

--- a/distribution/kubernetes/chart/values.yaml
+++ b/distribution/kubernetes/chart/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-logLevel: debug,hyper=warn,warp=warn
+logLevel: debug,hyper=warn,warp=warn,sqlx=warn
 maxSessionsPerOrchestrator: 5
 
 recording:

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -206,3 +206,7 @@ During the lifecycle of a session each component generates status codes for trac
 	orphaned = number
 }
 ```
+
+# Garbage collection
+
+Special considerations have been taken to ensure that most keys expire on their own (e.g. active manager/storage/api metadata). Those that do not expire on their own (e.g. sessions) will be purged by a dedicated garbage collector service.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -140,6 +140,8 @@ During the lifecycle of a session each component generates status codes for trac
 }
 
 `orchestrator:${ID}:heartbeat` = number EX 60
+`orchestrator:${ID}:retain` = number EX 604800 				// If this key is not set, the orchestrator metadata can be purged
+															// Expires after 7 days and is refreshed by a live orchestrator.
 
 `orchestrator:${ID}:capabilities:platformName` = string
 `orchestrator:${ID}:capabilities:browsers` = Set<string>    // explained below

--- a/docs/architecture/services.md
+++ b/docs/architecture/services.md
@@ -51,3 +51,6 @@ It receives requests through the proxy at `GET /storage/${SID}/*`.
 In order to route session traffic to the node that is hosting the session a reverse proxy is required. For this purpose (and load-balancing in a scenario with more than one manager instance) a service has been added.
 
 It listens on Redis key-space notifications to detect managers and nodes coming online or going offline, determined by their heartbeat. When a node comes online, the proxy routes all requests of the corresponding session (`/session/<ID>*`) to the node. For managers it routes requests matching `POST /session` to a randomly selected upstream from the list of alive managers.
+
+## Garbage collector
+As mentioned in the [database documentation](./database.md#garbage-collection), this service is responsible for removing old and unused keys from the database. Additionally, it has the task of resolving undefined states in the dataset which e.g. occured due to outages. This includes the termination of old sessions which have not been cleaned.


### PR DESCRIPTION
### 🔧 Changes
This PR adds a new `core` service which actively purges old data from the database. Additionally, it ensures internal consistency where possible. All keys that are not static (as in don't contain any identifiers) will be purged after a configurable amount of time. The default is set to 7 days which is currently not configurable through the Helm chart but is exposed by an ENV variable / command-line flag.