### PR TITLE
Implement prometheus metric provider

### DIFF
--- a/core/src/libraries/helpers/keys.rs
+++ b/core/src/libraries/helpers/keys.rs
@@ -157,3 +157,29 @@ pub mod storage {
         format!("{}:{}:host", storage_prefix(storage_id), provider_id)
     }
 }
+
+pub mod metrics {
+    pub mod http {
+        static_keys! {
+            NET_BYTES_TOTAL = "metrics:http:net.bytes.total".to_string();
+        }
+
+        pub fn requests_total(method: &str) -> String {
+            format!("metrics:http:requestsTotal:{}", method)
+        }
+    }
+
+    pub mod session {
+        pub fn log(level: &str) -> String {
+            format!("metrics:sessions:log:{}", level)
+        }
+
+        pub mod startup_histogram {
+            static_keys! {
+                BUCKETS = "metrics:sessions:startup.histogram:buckets".to_string();
+                SUM = "metrics:sessions:startup.histogram:sum".to_string();
+                COUNT = "metrics:sessions:startup.histogram:count".to_string();
+            }
+        }
+    }
+}

--- a/core/src/libraries/helpers/keys.rs
+++ b/core/src/libraries/helpers/keys.rs
@@ -182,4 +182,11 @@ pub mod metrics {
             }
         }
     }
+
+    pub mod storage {
+        static_keys! {
+            CAPACITY = "metrics:storage:disk.bytes.total".to_string();
+            USAGE = "metrics:storage:disk.bytes.used".to_string();
+        }
+    }
 }

--- a/core/src/libraries/metrics/entry.rs
+++ b/core/src/libraries/metrics/entry.rs
@@ -21,6 +21,6 @@ pub enum MetricsEntry {
     OutgoingTraffic(u64),
     RequestProcessed(Method, StatusCode),
     SessionStarted(f64),
-    // TODO This needs to be used somewhere.
-    SessionStatusChange(SessionStatus),
+    StorageCapacityUpdated(String, f64),
+    StorageUsageUpdated(String, f64),
 }

--- a/core/src/libraries/metrics/entry.rs
+++ b/core/src/libraries/metrics/entry.rs
@@ -1,0 +1,26 @@
+use hyper::http::{Method, StatusCode};
+use std::{fmt, fmt::Display};
+
+#[derive(Debug)]
+pub enum SessionStatus {
+    Queued,
+    Pending,
+    Alive,
+    Terminated,
+}
+
+impl Display for SessionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", format!("{:?}", self).to_lowercase())
+    }
+}
+
+#[derive(Debug)]
+pub enum MetricsEntry {
+    IncomingTraffic(u64),
+    OutgoingTraffic(u64),
+    RequestProcessed(Method, StatusCode),
+    SessionStarted(f64),
+    // TODO This needs to be used somewhere.
+    SessionStatusChange(SessionStatus),
+}

--- a/core/src/libraries/metrics/mod.rs
+++ b/core/src/libraries/metrics/mod.rs
@@ -1,0 +1,9 @@
+mod entry;
+mod processor;
+
+pub static SESSION_STARTUP_HISTOGRAM_BUCKETS: [i32; 16] = [
+    2, 4, 6, 8, 10, 12, 14, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096,
+];
+
+pub use entry::{MetricsEntry, SessionStatus};
+pub use processor::MetricsProcessor;

--- a/core/src/libraries/metrics/processor.rs
+++ b/core/src/libraries/metrics/processor.rs
@@ -1,0 +1,124 @@
+use super::entry::MetricsEntry;
+use super::SESSION_STARTUP_HISTOGRAM_BUCKETS;
+use crate::libraries::scheduling::{Job, TaskManager};
+use crate::{
+    libraries::resources::{ResourceManager, ResourceManagerProvider},
+    with_shared_redis_resource,
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use log::warn;
+use redis::{aio::ConnectionLike, AsyncCommands, RedisResult};
+use std::{marker::PhantomData, sync::Arc};
+use tokio::sync::{
+    mpsc::{error::SendError, unbounded_channel, UnboundedReceiver, UnboundedSender},
+    Mutex,
+};
+
+#[derive(Clone)]
+pub struct MetricsProcessor<C, R> {
+    tx: UnboundedSender<MetricsEntry>,
+    rx: Arc<Mutex<UnboundedReceiver<MetricsEntry>>>,
+    phantom_c: PhantomData<C>,
+    phantom_r: PhantomData<R>,
+}
+
+impl<C, R> Default for MetricsProcessor<C, R> {
+    fn default() -> Self {
+        let (tx, rx) = unbounded_channel();
+
+        Self {
+            tx,
+            rx: Arc::new(Mutex::new(rx)),
+            phantom_c: PhantomData,
+            phantom_r: PhantomData,
+        }
+    }
+}
+
+impl<C, R> MetricsProcessor<C, R> {
+    pub fn submit(&self, entry: MetricsEntry) -> Result<(), SendError<MetricsEntry>> {
+        self.tx.send(entry)
+    }
+
+    async fn process<Redis: AsyncCommands + ConnectionLike>(&self, con: &mut Redis) {
+        let rx = self.rx.clone();
+        let mut rx_lock = rx.lock().await;
+
+        while let Some(entry) = rx_lock.recv().await {
+            if let Err(e) = self.process_entry(con, entry).await {
+                warn!("Failed to update metric: {:?}", e);
+            }
+        }
+    }
+
+    async fn process_entry<Redis: AsyncCommands + ConnectionLike>(
+        &self,
+        con: &mut Redis,
+        entry: MetricsEntry,
+    ) -> RedisResult<()> {
+        match entry {
+            MetricsEntry::IncomingTraffic(bytes) => {
+                con.hincr::<_, _, _, ()>("metrics:http:net.bytes.total", "in", bytes)
+                    .await
+            }
+            MetricsEntry::OutgoingTraffic(bytes) => {
+                con.hincr::<_, _, _, ()>("metrics:http:net.bytes.total", "out", bytes)
+                    .await
+            }
+            MetricsEntry::RequestProcessed(method, status) => {
+                let key = format!("metrics:http:requestsTotal:{}", method.as_str().to_owned());
+                con.hincr::<_, _, _, ()>(key, status.as_u16(), 1).await
+            }
+            MetricsEntry::SessionStatusChange(new_status) => {
+                con.hincr::<_, _, _, ()>("metrics:sessions:total", format!("{}", new_status), 1)
+                    .await
+            }
+            MetricsEntry::SessionStarted(elapsed_time) => {
+                self.process_session_startup_histogram_entry(con, elapsed_time)
+                    .await
+            }
+        }
+    }
+
+    async fn process_session_startup_histogram_entry<Redis: AsyncCommands + ConnectionLike>(
+        &self,
+        con: &mut Redis,
+        elapsed_time: f64,
+    ) -> RedisResult<()> {
+        let base_key = "metrics:sessions:startup.histogram";
+        let buckets_key = format!("{}:buckets", base_key);
+        let count_key = format!("{}:count", base_key);
+        let sum_key = format!("{}:sum", base_key);
+
+        for bucket in SESSION_STARTUP_HISTOGRAM_BUCKETS.iter() {
+            let float_bucket: f64 = (*bucket).into();
+
+            if float_bucket > elapsed_time {
+                con.hincr::<_, _, _, ()>(&buckets_key, *bucket, 1).await?;
+            }
+        }
+
+        con.hincr::<_, _, _, ()>(&buckets_key, "+Inf", 1).await?;
+        con.incr::<_, _, ()>(count_key, 1).await?;
+        con.incr::<_, _, ()>(sum_key, elapsed_time).await
+    }
+}
+
+#[async_trait]
+impl<R: ResourceManager + Send + Sync, C: ResourceManagerProvider<R> + Send + Sync> Job
+    for MetricsProcessor<C, R>
+{
+    type Context = C;
+
+    const NAME: &'static str = module_path!();
+
+    async fn execute(&self, manager: TaskManager<Self::Context>) -> Result<()> {
+        let mut con = with_shared_redis_resource!(manager);
+
+        manager.ready().await;
+        self.process(&mut con).await;
+
+        Ok(())
+    }
+}

--- a/core/src/libraries/mod.rs
+++ b/core/src/libraries/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod helpers;
 pub mod lifecycle;
+pub mod metrics;
 pub mod resources;
 pub mod scheduling;
 pub mod storage;

--- a/core/src/libraries/resources/mod.rs
+++ b/core/src/libraries/resources/mod.rs
@@ -12,7 +12,8 @@ mod traits;
 pub use self::manager::DefaultResourceManager;
 pub use self::redis::{RedisResource, SharedRedisResource, StandaloneRedisResource};
 pub use traits::{
-    PubSub, PubSubResource, PubSubResourceError, ResourceManager, ResourceManagerResult,
+    PubSub, PubSubResource, PubSubResourceError, ResourceManager, ResourceManagerProvider,
+    ResourceManagerResult,
 };
 
 /// Shorthand to request a redis resource from a manager
@@ -23,7 +24,7 @@ macro_rules! with_redis_resource {
     ($manager:expr) => {
         $manager
             .context
-            .resource_manager
+            .resource_manager()
             .redis($manager.create_resource_handle())
             .await
             .expect("Unable to create redis resource")
@@ -38,7 +39,7 @@ macro_rules! with_shared_redis_resource {
     ($manager:expr) => {
         $manager
             .context
-            .resource_manager
+            .resource_manager()
             .shared_redis($manager.create_resource_handle())
             .await
             .expect("Unable to create redis resource")

--- a/core/src/libraries/resources/traits.rs
+++ b/core/src/libraries/resources/traits.rs
@@ -45,3 +45,16 @@ pub trait PubSubResource {
         &'a mut self,
     ) -> Pin<Box<dyn Stream<Item = Result<Msg, PubSubResourceError>> + Send + 'a>>;
 }
+
+pub trait ResourceManagerProvider<R: ResourceManager> {
+    fn resource_manager(&self) -> R;
+}
+
+impl<R> ResourceManagerProvider<R> for R
+where
+    R: ResourceManager + Clone,
+{
+    fn resource_manager(&self) -> R {
+        self.clone()
+    }
+}

--- a/core/src/libraries/storage/storage_handler.rs
+++ b/core/src/libraries/storage/storage_handler.rs
@@ -142,6 +142,11 @@ impl StorageHandler {
         res
     }
 
+    pub async fn used_bytes(&self) -> Result<f64, StorageError> {
+        let mut con = self.acquire_connection().await?;
+        Ok(database::used_bytes(&mut con).await?)
+    }
+
     /// Runs a cleanup if the used bytes exceed the `size_threshold`
     pub async fn maybe_cleanup(&self) -> Result<usize, StorageError> {
         let mut con = self.acquire_connection().await?;

--- a/core/src/libraries/storage/storage_handler.rs
+++ b/core/src/libraries/storage/storage_handler.rs
@@ -80,6 +80,7 @@ impl StorageHandler {
         cleanup_target: f64,
     ) -> Result<Self, StorageError> {
         let database_path = directory.join("storage.db");
+        Self::create_db_if_not_exists(&database_path).await?;
         let pool = SqlitePool::connect(&format!("sqlite://{}", database_path.display())).await?;
         let mut con = pool.acquire().await?;
         database::setup_tables(&mut con).await?;
@@ -90,6 +91,14 @@ impl StorageHandler {
             size_threshold,
             cleanup_target,
         })
+    }
+
+    async fn create_db_if_not_exists(path: &PathBuf) -> Result<(), std::io::Error> {
+        if !path.exists() {
+            tokio::fs::File::create(path).await?;
+        }
+
+        Ok(())
     }
 
     /// Explicitly scan the full filesystem and sync the database

--- a/core/src/services/gc/context.rs
+++ b/core/src/services/gc/context.rs
@@ -1,8 +1,8 @@
-use crate::libraries::resources::DefaultResourceManager;
+use crate::libraries::resources::{DefaultResourceManager, ResourceManagerProvider};
 
 #[derive(Clone)]
 pub struct Context {
-    pub resource_manager: DefaultResourceManager,
+    resource_manager: DefaultResourceManager,
 }
 
 impl Context {
@@ -10,5 +10,11 @@ impl Context {
         Self {
             resource_manager: DefaultResourceManager::new(redis_url),
         }
+    }
+}
+
+impl ResourceManagerProvider<DefaultResourceManager> for Context {
+    fn resource_manager(&self) -> DefaultResourceManager {
+        self.resource_manager.clone()
     }
 }

--- a/core/src/services/gc/jobs/garbage_collector.rs
+++ b/core/src/services/gc/jobs/garbage_collector.rs
@@ -1,4 +1,5 @@
 use super::super::Context;
+use crate::libraries::resources::ResourceManagerProvider;
 use crate::libraries::{
     helpers::{keys, lua},
     resources::ResourceManager,

--- a/core/src/services/manager/context.rs
+++ b/core/src/services/manager/context.rs
@@ -1,12 +1,13 @@
-use crate::libraries::resources::DefaultResourceManager;
 use crate::libraries::{helpers::keys, lifecycle::BeatValue};
 use crate::libraries::{lifecycle::HeartBeat, resources::ResourceManagerProvider};
+use crate::libraries::{metrics::MetricsProcessor, resources::DefaultResourceManager};
 use std::ops::Deref;
 
 #[derive(Clone)]
 pub struct Context {
-    pub resource_manager: DefaultResourceManager,
+    resource_manager: DefaultResourceManager,
     pub heart_beat: HeartBeat<Self, DefaultResourceManager>,
+    pub metrics: MetricsProcessor<Self, DefaultResourceManager>,
 }
 
 impl Context {
@@ -17,6 +18,7 @@ impl Context {
         Self {
             resource_manager: DefaultResourceManager::new(redis_url),
             heart_beat,
+            metrics: MetricsProcessor::default(),
         }
     }
 }

--- a/core/src/services/manager/mod.rs
+++ b/core/src/services/manager/mod.rs
@@ -44,11 +44,13 @@ pub async fn run(shared_options: SharedOptions, options: Options) {
 
     let status_job = StatusServer::new(&scheduler, shared_options.status_server);
     let heart_beat_job = context.heart_beat.clone();
+    let metrics_job = context.metrics.clone();
     let session_handler_job = SessionHandlerJob::new(options.port);
 
     schedule!(scheduler, context, {
         status_job,
         heart_beat_job,
+        metrics_job,
         session_handler_job
     });
 

--- a/core/src/services/manager/mod.rs
+++ b/core/src/services/manager/mod.rs
@@ -39,16 +39,16 @@ pub async fn run(shared_options: SharedOptions, options: Options) {
     let (mut heart, _) = Heart::new();
 
     let host = format!("{}:{}", options.host, options.port);
-    let context = Context::new(shared_options.redis, host);
+    let context = Context::new(shared_options.redis, host, &options.id).await;
     let scheduler = JobScheduler::default();
 
-    context.spawn_heart_beat(&options.id, &scheduler).await;
-
     let status_job = StatusServer::new(&scheduler, shared_options.status_server);
+    let heart_beat_job = context.heart_beat.clone();
     let session_handler_job = SessionHandlerJob::new(options.port);
 
     schedule!(scheduler, context, {
         status_job,
+        heart_beat_job,
         session_handler_job
     });
 

--- a/core/src/services/manager/tasks/create_session.rs
+++ b/core/src/services/manager/tasks/create_session.rs
@@ -3,7 +3,7 @@ use crate::libraries::helpers::{
     keys, parse_browser_string, wait_for, CapabilitiesRequest, Timeout,
 };
 use crate::libraries::lifecycle::logging::{LogCode, SessionLogger};
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::TaskManager;
 use crate::with_redis_resource;
 use chrono::offset::Utc;

--- a/core/src/services/metrics/context.rs
+++ b/core/src/services/metrics/context.rs
@@ -1,0 +1,14 @@
+use crate::libraries::resources::DefaultResourceManager;
+
+#[derive(Clone)]
+pub struct Context {
+    pub resource_manager: DefaultResourceManager,
+}
+
+impl Context {
+    pub fn new(redis_url: String) -> Self {
+        Self {
+            resource_manager: DefaultResourceManager::new(redis_url),
+        }
+    }
+}

--- a/core/src/services/metrics/context.rs
+++ b/core/src/services/metrics/context.rs
@@ -1,8 +1,8 @@
-use crate::libraries::resources::DefaultResourceManager;
+use crate::libraries::resources::{DefaultResourceManager, ResourceManagerProvider};
 
 #[derive(Clone)]
 pub struct Context {
-    pub resource_manager: DefaultResourceManager,
+    resource_manager: DefaultResourceManager,
 }
 
 impl Context {
@@ -10,5 +10,11 @@ impl Context {
         Self {
             resource_manager: DefaultResourceManager::new(redis_url),
         }
+    }
+}
+
+impl ResourceManagerProvider<DefaultResourceManager> for Context {
+    fn resource_manager(&self) -> DefaultResourceManager {
+        self.resource_manager.clone()
     }
 }

--- a/core/src/services/metrics/data_collector.rs
+++ b/core/src/services/metrics/data_collector.rs
@@ -219,3 +219,43 @@ pub async fn slots_available<C: AsyncCommands + ConnectionLike>(con: &mut C) -> 
         values: vec![MetricValue::from_value(slot_count)],
     }
 }
+
+pub async fn storage_capacity<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
+    let capacities: Vec<(String, f64)> = con
+        .hgetall(&*keys::metrics::storage::CAPACITY)
+        .await
+        .unwrap_or_default();
+
+    let values = capacities
+        .into_iter()
+        .map(|(id, capacity)| MetricValue::from_value(capacity).with_label("id", &id))
+        .collect();
+
+    Metric {
+        name: "webgrid_storage_disk_bytes_total".to_string(),
+        description: "Total number of bytes available for a given storage".to_string(),
+
+        metric_type: MetricType::Gauge,
+        values,
+    }
+}
+
+pub async fn storage_usage<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
+    let usages: Vec<(String, f64)> = con
+        .hgetall(&*keys::metrics::storage::USAGE)
+        .await
+        .unwrap_or_default();
+
+    let values = usages
+        .into_iter()
+        .map(|(id, usage)| MetricValue::from_value(usage).with_label("id", &id))
+        .collect();
+
+    Metric {
+        name: "webgrid_storage_disk_bytes_used".to_string(),
+        description: "Bytes used in a given storage".to_string(),
+
+        metric_type: MetricType::Gauge,
+        values,
+    }
+}

--- a/core/src/services/metrics/data_collector.rs
+++ b/core/src/services/metrics/data_collector.rs
@@ -1,6 +1,6 @@
-use super::structures::SESSION_STARTUP_HISTOGRAM_BUCKETS;
 use super::structures::{Metric, MetricType, MetricValue};
 use crate::libraries::helpers::keys;
+use crate::libraries::metrics::SESSION_STARTUP_HISTOGRAM_BUCKETS;
 use redis::{aio::ConnectionLike, AsyncCommands};
 
 static HTTP_METHODS: [&str; 9] = [

--- a/core/src/services/metrics/data_collector.rs
+++ b/core/src/services/metrics/data_collector.rs
@@ -1,38 +1,40 @@
-use crate::{Metric, MetricType, MetricValue};
-use redis::{aio::ConnectionManager, AsyncCommands};
-use shared::metrics::SESSION_STARTUP_HISTOGRAM_BUCKETS;
+use super::structures::SESSION_STARTUP_HISTOGRAM_BUCKETS;
+use super::structures::{Metric, MetricType, MetricValue};
+use crate::libraries::helpers::keys;
+use redis::{aio::ConnectionLike, AsyncCommands};
 
 static HTTP_METHODS: [&str; 9] = [
     "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "CONNECT", "PATCH", "TRACE",
 ];
 static LOG_LEVELS: [&str; 3] = ["INFO", "WARN", "FAIL"];
 
-pub async fn traffic_value(con: &mut ConnectionManager, direction: &str) -> MetricValue {
+pub async fn traffic_value<C: AsyncCommands + ConnectionLike>(
+    con: &mut C,
+    direction: &str,
+) -> MetricValue {
     let bytes: f64 = con
-        .hget("metrics:http:net.bytes.total", direction)
+        .hget(&*keys::metrics::http::NET_BYTES_TOTAL, direction)
         .await
         .unwrap_or_default();
 
     MetricValue::from_value(bytes).with_label("direction", direction)
 }
 
-pub async fn proxy_traffic(con: &ConnectionManager) -> Metric {
-    let mut con = con.clone();
-
+#[allow(clippy::eval_order_dependence)]
+pub async fn proxy_traffic<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
     Metric {
         name: "webgrid_proxy_http_net_bytes_total".to_string(),
         description: "Bytes (body only) transferred through all proxy instances".to_string(),
 
         metric_type: MetricType::Counter,
         values: vec![
-            traffic_value(&mut con, "in").await,
-            traffic_value(&mut con, "out").await,
+            traffic_value(con, "in").await,
+            traffic_value(con, "out").await,
         ],
     }
 }
 
-pub async fn proxy_requests(con: &ConnectionManager) -> Metric {
-    let mut con = con.clone();
+pub async fn proxy_requests<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
     let mut metric = Metric {
         name: "webgrid_proxy_http_requests_total".to_string(),
         description: "Requests processed by all proxy instances".to_string(),
@@ -43,7 +45,7 @@ pub async fn proxy_requests(con: &ConnectionManager) -> Metric {
 
     for method in HTTP_METHODS.iter() {
         if let Ok(status_codes) = con
-            .hgetall::<_, Vec<(String, f64)>>(format!("metrics:http:requestsTotal:{}", method))
+            .hgetall::<_, Vec<(String, f64)>>(keys::metrics::http::requests_total(method))
             .await
         {
             for (status_code, count) in status_codes {
@@ -59,8 +61,7 @@ pub async fn proxy_requests(con: &ConnectionManager) -> Metric {
     metric
 }
 
-pub async fn session_log(con: &ConnectionManager) -> Metric {
-    let mut con = con.clone();
+pub async fn session_log<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
     let mut metric = Metric {
         name: "webgrid_session_status_codes_total".to_string(),
         description: "Log codes for sessions".to_string(),
@@ -71,7 +72,7 @@ pub async fn session_log(con: &ConnectionManager) -> Metric {
 
     for log_level in LOG_LEVELS.iter() {
         if let Ok(log_codes) = con
-            .hgetall::<_, Vec<(String, f64)>>(format!("metrics:sessions:log:{}", log_level))
+            .hgetall::<_, Vec<(String, f64)>>(keys::metrics::session::log(log_level))
             .await
         {
             for (log_code, count) in log_codes {
@@ -87,10 +88,9 @@ pub async fn session_log(con: &ConnectionManager) -> Metric {
     metric
 }
 
-pub async fn session_startup_duration(con: &ConnectionManager) -> Metric {
-    let mut con = con.clone();
+pub async fn session_startup_duration<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
     let mut metric = Metric {
-        name: "session_startup_duration_seconds".to_string(),
+        name: "webgrid_session_startup_duration_seconds".to_string(),
         description: "Total startup duration of a session including queue and scheduling"
             .to_string(),
 
@@ -101,7 +101,10 @@ pub async fn session_startup_duration(con: &ConnectionManager) -> Metric {
     for bucket in SESSION_STARTUP_HISTOGRAM_BUCKETS.iter() {
         let bucket_name = bucket.to_string();
         let bucket_value = con
-            .hget("metrics:sessions:startup.histogram:buckets", &bucket_name)
+            .hget(
+                &*keys::metrics::session::startup_histogram::BUCKETS,
+                &bucket_name,
+            )
             .await
             .unwrap_or_default();
 
@@ -113,7 +116,7 @@ pub async fn session_startup_duration(con: &ConnectionManager) -> Metric {
     }
 
     let infinity_bucket_value = con
-        .hget("metrics:sessions:startup.histogram:buckets", "+Inf")
+        .hget(&*keys::metrics::session::startup_histogram::BUCKETS, "+Inf")
         .await
         .unwrap_or_default();
     metric.values.push(
@@ -123,7 +126,7 @@ pub async fn session_startup_duration(con: &ConnectionManager) -> Metric {
     );
 
     let sum_value = con
-        .get("metrics:sessions:startup.histogram:sum")
+        .get(&*keys::metrics::session::startup_histogram::SUM)
         .await
         .unwrap_or_default();
     metric
@@ -131,7 +134,7 @@ pub async fn session_startup_duration(con: &ConnectionManager) -> Metric {
         .push(MetricValue::from_value(sum_value).with_name_postfix("_sum"));
 
     let sum_value = con
-        .get("metrics:sessions:startup.histogram:count")
+        .get(&*keys::metrics::session::startup_histogram::COUNT)
         .await
         .unwrap_or_default();
     metric
@@ -141,16 +144,78 @@ pub async fn session_startup_duration(con: &ConnectionManager) -> Metric {
     metric
 }
 
-pub async fn sessions_active(con: &ConnectionManager) -> Metric {
-    let mut con = con.clone();
-
+pub async fn sessions_active<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
     Metric {
-        name: "sessions_active".to_string(),
+        name: "webgrid_sessions_active".to_string(),
         description: "Current number of active sessions (including queued and pending)".to_string(),
 
         metric_type: MetricType::Gauge,
         values: vec![MetricValue::from_value(
-            con.scard("sessions.active").await.unwrap_or_default(),
+            con.scard(&*keys::session::LIST_ACTIVE)
+                .await
+                .unwrap_or_default(),
         )],
+    }
+}
+
+pub async fn sessions_terminated<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
+    Metric {
+        name: "webgrid_sessions_terminated".to_string(),
+        description:
+            "Current number of terminated sessions that have not yet been purged from the database"
+                .to_string(),
+
+        metric_type: MetricType::Gauge,
+        values: vec![MetricValue::from_value(
+            con.scard(&*keys::session::LIST_TERMINATED)
+                .await
+                .unwrap_or_default(),
+        )],
+    }
+}
+
+pub async fn slots_total<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
+    let orchestrators: Vec<String> = con
+        .smembers(&*keys::orchestrator::LIST)
+        .await
+        .unwrap_or_default();
+
+    let mut slot_count = 0.0;
+    for orchestrator_id in orchestrators {
+        slot_count += con
+            .scard::<_, f64>(keys::orchestrator::slots::allocated(&orchestrator_id))
+            .await
+            .unwrap_or_default();
+    }
+
+    Metric {
+        name: "webgrid_slots_allocated".to_string(),
+        description: "Total number of allocated slots".to_string(),
+
+        metric_type: MetricType::Gauge,
+        values: vec![MetricValue::from_value(slot_count)],
+    }
+}
+
+pub async fn slots_available<C: AsyncCommands + ConnectionLike>(con: &mut C) -> Metric {
+    let orchestrators: Vec<String> = con
+        .smembers(&*keys::orchestrator::LIST)
+        .await
+        .unwrap_or_default();
+
+    let mut slot_count = 0.0;
+    for orchestrator_id in orchestrators {
+        slot_count += con
+            .llen::<_, f64>(keys::orchestrator::slots::available(&orchestrator_id))
+            .await
+            .unwrap_or_default();
+    }
+
+    Metric {
+        name: "webgrid_slots_available".to_string(),
+        description: "Total number of available slots".to_string(),
+
+        metric_type: MetricType::Gauge,
+        values: vec![MetricValue::from_value(slot_count)],
     }
 }

--- a/core/src/services/metrics/jobs/metric_handler.rs
+++ b/core/src/services/metrics/jobs/metric_handler.rs
@@ -70,6 +70,8 @@ impl MetricHandlerJob {
             sessions_terminated(&mut con).await,
             slots_available(&mut con).await,
             slots_total(&mut con).await,
+            storage_capacity(&mut con).await,
+            storage_usage(&mut con).await,
         ]
         .iter()
         .map(|metric| format!("{}", metric))

--- a/core/src/services/metrics/jobs/metric_handler.rs
+++ b/core/src/services/metrics/jobs/metric_handler.rs
@@ -1,6 +1,6 @@
 use super::super::data_collector::*;
 use super::super::Context;
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::{Job, TaskManager};
 use crate::with_redis_resource;
 use anyhow::Result;

--- a/core/src/services/metrics/jobs/metric_handler.rs
+++ b/core/src/services/metrics/jobs/metric_handler.rs
@@ -1,0 +1,83 @@
+use super::super::data_collector::*;
+use super::super::Context;
+use crate::libraries::resources::ResourceManager;
+use crate::libraries::scheduling::{Job, TaskManager};
+use crate::with_redis_resource;
+use anyhow::Result;
+use async_trait::async_trait;
+use log::info;
+use std::net::SocketAddr;
+use warp::Filter;
+
+#[derive(Clone)]
+pub struct MetricHandlerJob {
+    port: u16,
+}
+
+#[async_trait]
+impl Job for MetricHandlerJob {
+    type Context = Context;
+
+    const NAME: &'static str = module_path!();
+    const SUPPORTS_GRACEFUL_TERMINATION: bool = true;
+
+    async fn execute(&self, manager: TaskManager<Self::Context>) -> Result<()> {
+        let routes = self.routes(manager.clone());
+
+        let source_addr: SocketAddr = ([0, 0, 0, 0], self.port).into();
+        let (addr, server) = warp::serve(routes)
+            .bind_with_graceful_shutdown(source_addr, manager.termination_signal());
+
+        info!("Listening at {:?}", addr);
+        manager.ready().await;
+
+        server.await;
+
+        Ok(())
+    }
+}
+
+impl MetricHandlerJob {
+    pub fn new(port: u16) -> Self {
+        Self { port }
+    }
+
+    fn routes(
+        &self,
+        manager: TaskManager<Context>,
+    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+        let with_manager = warp::any().map(move || manager.clone());
+
+        warp::get()
+            .and(warp::path("metrics"))
+            .and(with_manager)
+            .and_then(MetricHandlerJob::handle_get)
+    }
+
+    async fn handle_get(
+        manager: TaskManager<Context>,
+    ) -> Result<impl warp::Reply, warp::Rejection> {
+        let mut con = with_redis_resource!(manager);
+
+        #[allow(clippy::eval_order_dependence)]
+        let metrics: Vec<String> = vec![
+            proxy_requests(&mut con).await,
+            proxy_traffic(&mut con).await,
+            session_log(&mut con).await,
+            session_startup_duration(&mut con).await,
+            // TODO Replace later with session_total{stage="queued|pending|alive|terminated"} counter
+            sessions_active(&mut con).await,
+            sessions_terminated(&mut con).await,
+            slots_available(&mut con).await,
+            slots_total(&mut con).await,
+        ]
+        .iter()
+        .map(|metric| format!("{}", metric))
+        .collect();
+
+        Ok(warp::reply::with_status(
+            metrics.join("\n"),
+            warp::http::StatusCode::OK,
+        ))
+    }
+}

--- a/core/src/services/metrics/jobs/mod.rs
+++ b/core/src/services/metrics/jobs/mod.rs
@@ -1,0 +1,3 @@
+mod metric_handler;
+
+pub use metric_handler::MetricHandlerJob;

--- a/core/src/services/metrics/mod.rs
+++ b/core/src/services/metrics/mod.rs
@@ -1,32 +1,42 @@
 //! Prometheus metric provider
 
 use super::SharedOptions;
-use crate::libraries::helpers::constants::PORT_METRICS;
+use crate::libraries::helpers::constants;
 use crate::libraries::lifecycle::Heart;
 use crate::libraries::scheduling::{JobScheduler, StatusServer};
 use crate::schedule;
+use context::Context;
+use jobs::MetricHandlerJob;
 use log::info;
 use structopt::StructOpt;
+
+mod context;
+mod data_collector;
+mod jobs;
+mod structures;
 
 #[derive(Debug, StructOpt)]
 /// Prometheus metric provider
 ///
 /// Uses lifecycle and health probes from all active grid components to provide metrics for Prometheus.
-pub struct Options {}
+pub struct Options {
+    /// Port on which the HTTP server will listen
+    #[structopt(short, long, default_value = constants::PORT_METRICS)]
+    port: u16,
+}
 
-#[derive(Clone)]
-struct DummyContext {}
-
-pub async fn run(shared_options: SharedOptions, _options: Options) {
+pub async fn run(shared_options: SharedOptions, options: Options) {
     let scheduler = JobScheduler::default();
     let (mut heart, _) = Heart::new();
-    let context = DummyContext {};
+    let context = Context::new(shared_options.redis);
 
     let status_job = StatusServer::new(&scheduler, shared_options.status_server);
+    let metrics_job = MetricHandlerJob::new(options.port);
 
-    println!("This should listen on {}", PORT_METRICS);
-
-    schedule!(scheduler, context, { status_job });
+    schedule!(scheduler, context, {
+        status_job,
+        metrics_job
+    });
 
     let death_reason = heart.death().await;
     info!("Heart died: {}", death_reason);

--- a/core/src/services/metrics/structures.rs
+++ b/core/src/services/metrics/structures.rs
@@ -2,6 +2,10 @@ use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::fmt;
 
+pub static SESSION_STARTUP_HISTOGRAM_BUCKETS: [i32; 16] = [
+    2, 4, 6, 8, 10, 12, 14, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096,
+];
+
 #[derive(Debug)]
 pub enum MetricType {
     Counter,

--- a/core/src/services/metrics/structures.rs
+++ b/core/src/services/metrics/structures.rs
@@ -2,10 +2,6 @@ use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::fmt;
 
-pub static SESSION_STARTUP_HISTOGRAM_BUCKETS: [i32; 16] = [
-    2, 4, 6, 8, 10, 12, 14, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096,
-];
-
 #[derive(Debug)]
 pub enum MetricType {
     Counter,

--- a/core/src/services/node/context.rs
+++ b/core/src/services/node/context.rs
@@ -1,33 +1,38 @@
 use super::{tasks::DriverReference, Options};
-use crate::libraries::helpers::keys;
 use crate::libraries::lifecycle::HeartBeat;
 use crate::libraries::resources::DefaultResourceManager;
-use crate::libraries::scheduling::JobScheduler;
+use crate::libraries::{helpers::keys, resources::ResourceManagerProvider};
 
 #[derive(Clone)]
 pub struct Context {
-    pub resource_manager: DefaultResourceManager,
+    resource_manager: DefaultResourceManager,
     pub driver_reference: DriverReference,
-    pub heart_beat: HeartBeat<DefaultResourceManager>,
+    pub heart_beat: HeartBeat<Self, DefaultResourceManager>,
     pub id: String,
     pub options: Options,
 }
 
 impl Context {
-    pub fn new(redis_url: String, options: Options) -> Self {
+    pub async fn new(redis_url: String, options: Options) -> Self {
+        let id = options.id.clone();
+        let heart_beat = HeartBeat::new();
+
+        heart_beat
+            .add_beat(&keys::session::heartbeat::node(&id), 60, 120)
+            .await;
+
         Self {
             resource_manager: DefaultResourceManager::new(redis_url),
             driver_reference: DriverReference::new(),
-            heart_beat: HeartBeat::new(),
-            id: options.id.clone(),
+            heart_beat,
+            id,
             options,
         }
     }
+}
 
-    pub async fn spawn_heart_beat(&self, scheduler: &JobScheduler) {
-        self.heart_beat
-            .add_beat(&keys::session::heartbeat::node(&self.id), 60, 120)
-            .await;
-        scheduler.spawn_job(self.heart_beat.clone(), self.resource_manager.clone());
+impl ResourceManagerProvider<DefaultResourceManager> for Context {
+    fn resource_manager(&self) -> DefaultResourceManager {
+        self.resource_manager.clone()
     }
 }

--- a/core/src/services/node/tasks/driver.rs
+++ b/core/src/services/node/tasks/driver.rs
@@ -1,7 +1,7 @@
 use super::super::{structs::NodeError, Context};
 use crate::libraries::helpers::{wait_for, Timeout};
 use crate::libraries::lifecycle::logging::{LogCode, SessionLogger};
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::TaskManager;
 use crate::with_redis_resource;
 use log::{error, info};

--- a/core/src/services/node/tasks/init_service.rs
+++ b/core/src/services/node/tasks/init_service.rs
@@ -4,7 +4,7 @@ use crate::libraries::lifecycle::{
     logging::{LogCode, SessionLogger},
     Heart, HeartStone,
 };
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::TaskManager;
 use crate::libraries::storage::StorageHandler;
 use crate::with_redis_resource;

--- a/core/src/services/node/tasks/init_session.rs
+++ b/core/src/services/node/tasks/init_session.rs
@@ -4,7 +4,7 @@ use super::super::{
 };
 use crate::libraries::helpers::keys;
 use crate::libraries::lifecycle::logging::{LogCode, SessionLogger};
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::TaskManager;
 use crate::with_redis_resource;
 use hyper::{body, Body, Client as HttpClient, Method, Request};

--- a/core/src/services/node/tasks/log_exit.rs
+++ b/core/src/services/node/tasks/log_exit.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use super::super::{structs::NodeError, Context};
 use crate::libraries::lifecycle::logging::{LogCode, SessionLogger};
 use crate::libraries::lifecycle::DeathReason;
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::TaskManager;
 use crate::with_shared_redis_resource;
 use futures::Future;

--- a/core/src/services/node/tasks/terminate.rs
+++ b/core/src/services/node/tasks/terminate.rs
@@ -1,7 +1,7 @@
 use super::super::{structs::NodeError, Context};
 use crate::libraries::helpers::lua;
 use crate::libraries::lifecycle::logging::{LogCode, SessionLogger};
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::TaskManager;
 use crate::with_shared_redis_resource;
 use chrono::offset::Utc;

--- a/core/src/services/orchestrator/core/context.rs
+++ b/core/src/services/orchestrator/core/context.rs
@@ -1,44 +1,47 @@
 use super::{Provisioner, ProvisionerType};
-use crate::libraries::helpers::keys;
 use crate::libraries::lifecycle::HeartBeat;
 use crate::libraries::resources::DefaultResourceManager;
-use crate::libraries::scheduling::JobScheduler;
+use crate::libraries::{helpers::keys, resources::ResourceManagerProvider};
 use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct Context {
-    pub resource_manager: DefaultResourceManager,
-    pub heart_beat: HeartBeat<DefaultResourceManager>,
+    resource_manager: DefaultResourceManager,
+    pub heart_beat: HeartBeat<Self, DefaultResourceManager>,
     pub provisioner: Arc<Box<dyn Provisioner + Send + Sync + 'static>>,
     pub provisioner_type: ProvisionerType,
     pub id: String,
 }
 
 impl Context {
-    pub fn new<P: Provisioner + Send + Sync + Clone + 'static>(
+    pub async fn new<P: Provisioner + Send + Sync + Clone + 'static>(
         provisioner_type: ProvisionerType,
         provisioner: P,
         redis_url: String,
         id: String,
     ) -> Self {
+        let heart_beat = HeartBeat::new();
+
+        heart_beat
+            .add_beat(&keys::orchestrator::heartbeat(&id), 60, 120)
+            .await;
+
+        heart_beat
+            .add_beat(&keys::orchestrator::retain(&id), 300, 604_800)
+            .await;
+
         Self {
             resource_manager: DefaultResourceManager::new(redis_url),
-            heart_beat: HeartBeat::new(),
+            heart_beat,
             provisioner: Arc::new(Box::new(provisioner)),
             provisioner_type,
             id,
         }
     }
+}
 
-    pub async fn spawn_heart_beat(&self, scheduler: &JobScheduler) {
-        self.heart_beat
-            .add_beat(&keys::orchestrator::heartbeat(&self.id), 60, 120)
-            .await;
-
-        self.heart_beat
-            .add_beat(&keys::orchestrator::retain(&self.id), 300, 604_800)
-            .await;
-
-        scheduler.spawn_job(self.heart_beat.clone(), self.resource_manager.clone());
+impl ResourceManagerProvider<DefaultResourceManager> for Context {
+    fn resource_manager(&self) -> DefaultResourceManager {
+        self.resource_manager.clone()
     }
 }

--- a/core/src/services/orchestrator/core/jobs/node_watcher.rs
+++ b/core/src/services/orchestrator/core/jobs/node_watcher.rs
@@ -1,5 +1,5 @@
 use super::super::Context;
-use crate::libraries::resources::{PubSub, ResourceManager};
+use crate::libraries::resources::{PubSub, ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::{Job, TaskManager};
 use crate::with_redis_resource;
 use anyhow::{bail, Result};

--- a/core/src/services/orchestrator/core/jobs/processor.rs
+++ b/core/src/services/orchestrator/core/jobs/processor.rs
@@ -1,7 +1,7 @@
 use super::super::Context;
 use crate::libraries::helpers::keys;
 use crate::libraries::lifecycle::logging::{LogCode, Logger};
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::{Job, TaskManager};
 use crate::with_redis_resource;
 use anyhow::Result;

--- a/core/src/services/orchestrator/core/jobs/registration.rs
+++ b/core/src/services/orchestrator/core/jobs/registration.rs
@@ -1,5 +1,5 @@
 use super::super::Context;
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::{Job, TaskManager};
 use crate::with_shared_redis_resource;
 use anyhow::Result;

--- a/core/src/services/orchestrator/core/jobs/slot_count_adjuster.rs
+++ b/core/src/services/orchestrator/core/jobs/slot_count_adjuster.rs
@@ -1,6 +1,6 @@
 use super::super::Context;
 use crate::libraries::helpers::keys;
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::{Job, TaskManager};
 use crate::{with_redis_resource, with_shared_redis_resource};
 use anyhow::Result;

--- a/core/src/services/orchestrator/core/jobs/slot_reclaim.rs
+++ b/core/src/services/orchestrator/core/jobs/slot_reclaim.rs
@@ -1,6 +1,6 @@
 use super::super::Context;
 use crate::libraries::helpers::{lua::terminate_session, Timeout};
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::{Job, TaskManager};
 use crate::with_shared_redis_resource;
 use anyhow::Result;

--- a/core/src/services/orchestrator/core/jobs/slot_recycle.rs
+++ b/core/src/services/orchestrator/core/jobs/slot_recycle.rs
@@ -1,6 +1,6 @@
 use super::super::Context;
 use crate::libraries::helpers::keys;
-use crate::libraries::resources::ResourceManager;
+use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::{Job, TaskManager};
 use crate::with_redis_resource;
 use anyhow::Result;

--- a/core/src/services/orchestrator/core/mod.rs
+++ b/core/src/services/orchestrator/core/mod.rs
@@ -42,12 +42,12 @@ pub async fn start<P: Provisioner + Send + Sync + Clone + 'static>(
         provisioner,
         shared_options.redis,
         options.id,
-    );
+    )
+    .await;
     let scheduler = JobScheduler::default();
 
-    context.spawn_heart_beat(&scheduler).await;
-
     let status_job = StatusServer::new(&scheduler, shared_options.status_server);
+    let heart_beat_job = context.heart_beat.clone();
     let registration_job = RegistrationJob::new();
     let node_watcher_job = NodeWatcherJob::new();
     let slot_reclaim_job = SlotReclaimJob::new();
@@ -57,6 +57,7 @@ pub async fn start<P: Provisioner + Send + Sync + Clone + 'static>(
 
     schedule!(scheduler, context, {
         status_job,
+        heart_beat_job,
         registration_job
         node_watcher_job
         processor_job

--- a/core/src/services/orchestrator/provisioners/docker/provisioner.rs
+++ b/core/src/services/orchestrator/provisioners/docker/provisioner.rs
@@ -38,11 +38,13 @@ impl DockerProvisioner {
 #[async_trait]
 impl Provisioner for DockerProvisioner {
     fn capabilities(&self) -> ProvisionerCapabilities {
-        let browsers = self.images.iter().cloned().map(|i| i.1).collect();
-
         ProvisionerCapabilities {
             platform_name: "linux".to_owned(),
-            browsers,
+            browsers: self
+                .images
+                .iter()
+                .map(|(_, browser)| browser.to_owned())
+                .collect(),
         }
     }
 

--- a/core/src/services/orchestrator/provisioners/kubernetes/provisioner.rs
+++ b/core/src/services/orchestrator/provisioners/kubernetes/provisioner.rs
@@ -145,7 +145,11 @@ impl Provisioner for K8sProvisioner {
     fn capabilities(&self) -> ProvisionerCapabilities {
         ProvisionerCapabilities {
             platform_name: "linux".to_owned(),
-            browsers: Vec::new(),
+            browsers: self
+                .images
+                .iter()
+                .map(|(_, browser)| browser.to_owned())
+                .collect(),
         }
     }
 

--- a/core/src/services/proxy/context.rs
+++ b/core/src/services/proxy/context.rs
@@ -1,10 +1,14 @@
 use super::routing_info::RoutingInfo;
-use crate::libraries::resources::{DefaultResourceManager, ResourceManagerProvider};
+use crate::libraries::{
+    metrics::MetricsProcessor,
+    resources::{DefaultResourceManager, ResourceManagerProvider},
+};
 
 #[derive(Clone)]
 pub struct Context {
     resource_manager: DefaultResourceManager,
     pub routing_info: RoutingInfo,
+    pub metrics: MetricsProcessor<Self, DefaultResourceManager>,
 }
 
 impl Context {
@@ -12,6 +16,7 @@ impl Context {
         Self {
             resource_manager: DefaultResourceManager::new(redis_url),
             routing_info: RoutingInfo::new(),
+            metrics: MetricsProcessor::default(),
         }
     }
 }

--- a/core/src/services/proxy/context.rs
+++ b/core/src/services/proxy/context.rs
@@ -1,9 +1,9 @@
 use super::routing_info::RoutingInfo;
-use crate::libraries::resources::DefaultResourceManager;
+use crate::libraries::resources::{DefaultResourceManager, ResourceManagerProvider};
 
 #[derive(Clone)]
 pub struct Context {
-    pub resource_manager: DefaultResourceManager,
+    resource_manager: DefaultResourceManager,
     pub routing_info: RoutingInfo,
 }
 
@@ -13,5 +13,11 @@ impl Context {
             resource_manager: DefaultResourceManager::new(redis_url),
             routing_info: RoutingInfo::new(),
         }
+    }
+}
+
+impl ResourceManagerProvider<DefaultResourceManager> for Context {
+    fn resource_manager(&self) -> DefaultResourceManager {
+        self.resource_manager.clone()
     }
 }

--- a/core/src/services/proxy/jobs/watcher.rs
+++ b/core/src/services/proxy/jobs/watcher.rs
@@ -1,6 +1,6 @@
 use super::super::{routing_info::RoutingInfo, Context};
 use crate::libraries::helpers::keys;
-use crate::libraries::resources::{PubSub, ResourceManager};
+use crate::libraries::resources::{PubSub, ResourceManager, ResourceManagerProvider};
 use crate::libraries::scheduling::{Job, TaskManager};
 use crate::with_redis_resource;
 use anyhow::{bail, Context as AnyhowContext, Result};

--- a/core/src/services/proxy/mod.rs
+++ b/core/src/services/proxy/mod.rs
@@ -32,11 +32,13 @@ pub async fn run(shared_options: SharedOptions, options: Options) {
     let scheduler = JobScheduler::default();
 
     let status_job = StatusServer::new(&scheduler, shared_options.status_server);
+    let metrics_job = context.metrics.clone();
     let watcher_job = WatcherJob::new();
     let proxy_job = ProxyJob::new(options.port);
 
     schedule!(scheduler, context, {
         status_job,
+        metrics_job,
         watcher_job,
         proxy_job
     });

--- a/core/src/services/storage/context.rs
+++ b/core/src/services/storage/context.rs
@@ -1,12 +1,16 @@
-use crate::libraries::lifecycle::{BeatValue, HeartBeat};
 use crate::libraries::resources::DefaultResourceManager;
 use crate::libraries::{helpers::keys, resources::ResourceManagerProvider};
+use crate::libraries::{
+    lifecycle::{BeatValue, HeartBeat},
+    metrics::MetricsProcessor,
+};
 
 #[derive(Clone)]
 pub struct Context {
     resource_manager: DefaultResourceManager,
     pub heart_beat: HeartBeat<Self, DefaultResourceManager>,
     pub storage_id: String,
+    pub metrics: MetricsProcessor<Self, DefaultResourceManager>,
 }
 
 impl Context {
@@ -28,6 +32,7 @@ impl Context {
             resource_manager: DefaultResourceManager::new(redis_url),
             heart_beat,
             storage_id,
+            metrics: MetricsProcessor::default(),
         }
     }
 }

--- a/core/src/services/storage/mod.rs
+++ b/core/src/services/storage/mod.rs
@@ -64,12 +64,14 @@ pub async fn run(shared_options: SharedOptions, options: Options) -> Result<()> 
 
     let status_job = StatusServer::new(&scheduler, shared_options.status_server);
     let heart_beat_job = context.heart_beat.clone();
+    let metrics_job = context.metrics.clone();
     let server_job = ServerJob::new(options.port, options.storage_directory.clone());
     let cleanup_job = CleanupJob::new(options.storage_directory, size_limit, cleanup_target);
 
     schedule!(scheduler, context, {
         status_job,
         heart_beat_job,
+        metrics_job,
         server_job,
         cleanup_job
     });

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -201,11 +201,22 @@ During the lifecycle of a session each component generates status codes for trac
 }
 ```
 
-#### Slots
+#### Orchestrator
 ```javascript
 `metrics:slots:reclaimed.total` = Hashes {
 	dead = number
 	orphaned = number
+}
+```
+
+#### Storage
+```javascript
+`metrics:storage:disk.bytes.total` = Hashes {
+	<storage-id> = number
+}
+
+`metrics:storage:disk.bytes.used` = Hashes {
+	<storage-id> = number
 }
 ```
 


### PR DESCRIPTION
### 🔧 Changes
This PR revives most of the metrics that have been available prior to the huge job scheduler refactoring where they got lost in the process. The API has been adapted to all new project standards like extracted keys and Jobs.

Additionally, some new metrics have been added for the orchestrator and storage services.

Finally, minor bugfixes in the storage service (in accordance to a change in SQLite which now refuses to create a new database on its own) and K8s orchestrator, which did not expose the supported browsers in its capabilities.