### PR TITLE
Add git version log on startup and in help text

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,6 +14,8 @@ jobs:
         working-directory: core
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/cache@v2
         with:
           path: |

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -242,6 +242,9 @@ name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -587,6 +590,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.13.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d250f5f82326884bd39c2853577e70a121775db76818ffa452ed1e80de12986"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +831,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,12 +949,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.18+1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d31059f22935e6c31830db5249ba2b7ecd54fd73a9909286f0a67aa55c2fbd"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0186af0d8f171ae6b9c4c90ec51898bad5d08a2d5e470903a50d9ad8959cbee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2420,13 +2487,14 @@ dependencies = [
 
 [[package]]
 name = "webgrid"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "bollard",
  "chrono",
  "futures",
+ "git2",
  "hyper",
  "k8s-openapi",
  "kube",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webgrid"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Til Blechschmidt <til@blechschmidt.de>"]
 edition = "2018"
 
@@ -40,6 +40,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 sqlx = { version = "0.5", default-features = false, features = [ "macros", "sqlite", "runtime-tokio-native-tls" ] }
 tokio = { version = "1.2", features = ["full"] }
+git2 = "0.13"
 
 [features]
 default = ["gc", "proxy", "manager", "node", "metrics", "storage", "docker", "kubernetes"]

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,10 +1,12 @@
+use git2::{DescribeFormatOptions, DescribeOptions, Repository};
 use serde::Deserialize;
 use sqlx::{Connection, SqliteConnection};
-use std::collections::HashMap;
 use std::env;
 use std::fs::{read_to_string, remove_file, File};
 use std::io::prelude::*;
 use std::path::PathBuf;
+use std::{collections::HashMap, str::FromStr};
+// use vergen::{vergen, Config, SemverKind, ShaKind};
 
 #[derive(Debug, Deserialize)]
 struct Constants {
@@ -21,6 +23,30 @@ struct Ports {
 async fn main() {
     generate_typecheck_database().await;
     generate_constants();
+    generate_version_info();
+}
+
+fn generate_version_info() {
+    let repo_dir = if let Some(path_str) = option_env!("WEBGRID_GIT_REPOSITORY") {
+        PathBuf::from_str(path_str).unwrap()
+    } else {
+        let rust_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();
+        rust_dir.parent().unwrap().to_path_buf()
+    };
+
+    let repository = Repository::open(&repo_dir).unwrap();
+
+    let mut describe_opts = DescribeOptions::new();
+    describe_opts.describe_tags();
+
+    let mut describe_format_opts = DescribeFormatOptions::new();
+    describe_format_opts.dirty_suffix("-dirty");
+
+    let description = repository.describe(&describe_opts).unwrap();
+    let version = description.format(Some(&describe_format_opts)).unwrap();
+
+    println!("cargo:rustc-env=WEBGRID_VERSION={}", version);
+    println!("cargo:rerun-if-changed={}", repo_dir.join(".git").display());
 }
 
 async fn generate_typecheck_database() {

--- a/core/build.sh
+++ b/core/build.sh
@@ -33,11 +33,14 @@ echo "Copying project to build cache"
 rsync -a --progress $SOURCE_DIR/* $BUILD_DIR/project --exclude target --exclude .build --exclude .cache
 
 echo "Running build in webgrid/rust-musl-builder:${BUILDER_TAG} container"
+# We are mounting the repository into the container for the build-script to determine the version from git
 docker run --rm --name core-build \
 	-v "$BUILD_DIR/project":/home/rust/src \
 	-v "$BUILD_DIR/cargo-git":/home/rust/.cargo/git \
 	-v "$BUILD_DIR/cargo-registry":/home/rust/.cargo/registry \
 	-v "$BUILD_DIR/target":/home/rust/src/target \
+	-v "$(pwd)/../":/repository \
+	-e WEBGRID_GIT_REPOSITORY=/repository \
 	-e CARGO_TERM_COLOR=always \
 	webgrid/rust-musl-builder:${BUILDER_TAG} \
 	bash -c "cargo build ${RELEASE_FLAG} --locked && cargo doc ${RELEASE_FLAG} --locked --no-deps && rm -f /home/rust/src/target/x86_64-unknown-linux-musl/doc/.lock"

--- a/core/build.sh
+++ b/core/build.sh
@@ -45,7 +45,6 @@ docker run --rm --name core-build \
 	webgrid/rust-musl-builder:${BUILDER_TAG} \
 	bash -c "cargo build ${RELEASE_FLAG} --locked && cargo doc ${RELEASE_FLAG} --locked --no-deps && rm -f /home/rust/src/target/x86_64-unknown-linux-musl/doc/.lock"
 
-# TODO: Strip debug symbols from binary
 
 echo "Creating output directories in $TARGET_DIR"
 mkdir -p $TARGET_DIR/core-documentation
@@ -55,3 +54,13 @@ echo "Copying documentation to output"
 rsync -a --progress $BUILD_DIR/target/x86_64-unknown-linux-musl/doc $TARGET_DIR/core-documentation
 echo "Copying executable to output"
 rsync -av --progress $BUILD_DIR/target/x86_64-unknown-linux-musl/$BUILD_OUTPUT_DIR/webgrid $TARGET_DIR/core-executable
+
+# Strip the binary
+if [[ $1 = "--release" ]];
+then
+	echo "Stripping binary"
+	docker run --rm --name core-strip \
+		-v $TARGET_DIR/core-executable:/output \
+		alpine \
+		sh -c "apk add --update binutils && ls /output && strip /output/webgrid"
+fi

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -6,7 +6,10 @@ use webgrid::services::orchestrator::{provisioners, Provisioner};
 use webgrid::services::*;
 
 #[derive(Debug, StructOpt)]
-#[structopt(about = "Decentralized, scalable and robust selenium-grid equivalent.")]
+#[structopt(
+    about = "Decentralized, scalable and robust selenium-grid equivalent.",
+    version = env!("WEBGRID_VERSION")
+)]
 struct MainOptions {
     #[structopt(flatten)]
     shared_options: SharedOptions,
@@ -47,6 +50,8 @@ async fn main() -> Result<()> {
     pretty_env_logger::formatted_timed_builder()
         .parse_filters(&shared_options.log)
         .init();
+
+    log::info!("{}", env!("WEBGRID_VERSION"));
 
     match main_options.cmd {
         #[cfg(feature = "metrics")]


### PR DESCRIPTION
### 🔧 Changes
This PR adds a log output of the version from which the core service was built. It is mostly equal to `git describe --tags --dirty`.