### PR TITLE
Reduce SQLite database accesses

### DIFF
--- a/core/src/libraries/helpers/keys.rs
+++ b/core/src/libraries/helpers/keys.rs
@@ -156,6 +156,14 @@ pub mod storage {
     pub fn host(storage_id: &str, provider_id: &str) -> String {
         format!("{}:{}:host", storage_prefix(storage_id), provider_id)
     }
+
+    pub mod metadata {
+        use super::storage_prefix;
+
+        pub fn pending(storage_id: &str) -> String {
+            format!("{}:metadata.pending", storage_prefix(storage_id))
+        }
+    }
 }
 
 pub mod metrics {

--- a/core/src/libraries/storage/mod.rs
+++ b/core/src/libraries/storage/mod.rs
@@ -6,4 +6,4 @@ mod database;
 mod scan;
 mod storage_handler;
 
-pub use self::storage_handler::{StorageError, StorageHandler};
+pub use self::storage_handler::{FileMetadata, StorageError, StorageHandler};

--- a/core/src/libraries/storage/scan.rs
+++ b/core/src/libraries/storage/scan.rs
@@ -5,6 +5,8 @@ use tokio::{
     sync::{Mutex, Notify, Semaphore},
 };
 
+use super::FileMetadata;
+
 #[derive(Clone)]
 pub struct FileSystemScanner {
     root: PathBuf,
@@ -136,7 +138,9 @@ impl FileSystemScanner {
         }
 
         let mut con = self.transaction.lock().await;
-        super::database::insert_file(path_str, entry.metadata().await.ok(), &mut *con)
+        let metadata =
+            FileMetadata::from_fs_metadata(PathBuf::from(path_str), entry.metadata().await);
+        super::database::insert_file(metadata, &mut *con)
             .await
             .unwrap();
     }

--- a/core/src/services/node/tasks/init_service.rs
+++ b/core/src/services/node/tasks/init_service.rs
@@ -22,7 +22,7 @@ pub async fn initialize_service(
     ));
 
     if let Some(storage_directory) = manager.context.options.storage_directory {
-        let storage_id = StorageHandler::storage_id(storage_directory.clone())
+        let storage_id = StorageHandler::storage_id(&storage_directory)
             .await
             .map_err(|e| {
                 error!("Storage unavailable: {:?}", e);

--- a/core/src/services/storage/context.rs
+++ b/core/src/services/storage/context.rs
@@ -1,9 +1,11 @@
-use crate::libraries::resources::DefaultResourceManager;
+use super::Options;
 use crate::libraries::{helpers::keys, resources::ResourceManagerProvider};
 use crate::libraries::{
     lifecycle::{BeatValue, HeartBeat},
     metrics::MetricsProcessor,
 };
+use crate::libraries::{resources::DefaultResourceManager, storage::StorageHandler};
+use anyhow::Result;
 
 #[derive(Clone)]
 pub struct Context {
@@ -11,29 +13,39 @@ pub struct Context {
     pub heart_beat: HeartBeat<Self, DefaultResourceManager>,
     pub storage_id: String,
     pub metrics: MetricsProcessor<Self, DefaultResourceManager>,
+    pub storage: StorageHandler,
 }
 
 impl Context {
     pub async fn new(
+        options: &Options,
         redis_url: String,
         storage_id: String,
         provider_id: String,
-        host: String,
-        port: u16,
-    ) -> Self {
-        let addr = format!("{}:{}", host, port);
+        size_threshold: f64,
+        cleanup_target: f64,
+    ) -> Result<Self> {
+        let addr = format!("{}:{}", options.host, options.port);
         let heart_beat = HeartBeat::with_value(BeatValue::Constant(addr));
 
         heart_beat
             .add_beat(&keys::storage::host(&storage_id, &provider_id), 60, 120)
             .await;
 
-        Self {
+        let storage = StorageHandler::new(
+            options.storage_directory.clone(),
+            size_threshold,
+            cleanup_target,
+        )
+        .await?;
+
+        Ok(Self {
             resource_manager: DefaultResourceManager::new(redis_url),
             heart_beat,
             storage_id,
             metrics: MetricsProcessor::default(),
-        }
+            storage,
+        })
     }
 }
 

--- a/core/src/services/storage/jobs/cleanup.rs
+++ b/core/src/services/storage/jobs/cleanup.rs
@@ -1,18 +1,15 @@
 use super::super::Context;
 use crate::libraries::metrics::MetricsEntry;
 use crate::libraries::scheduling::{Job, TaskManager};
-use crate::libraries::storage::StorageHandler;
 use anyhow::Result;
 use async_trait::async_trait;
 use log::{debug, info, warn};
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 use tokio::time::sleep;
 
 #[derive(Clone)]
 pub struct CleanupJob {
-    storage_directory: PathBuf,
     size_threshold: f64,
-    cleanup_target: f64,
 }
 
 #[async_trait]
@@ -31,12 +28,7 @@ impl Job for CleanupJob {
             ))
             .ok();
 
-        let storage = StorageHandler::new(
-            self.storage_directory.clone(),
-            self.size_threshold,
-            self.cleanup_target,
-        )
-        .await?;
+        let storage = &manager.context.storage;
 
         manager.ready().await;
 
@@ -80,13 +72,7 @@ impl Job for CleanupJob {
 }
 
 impl CleanupJob {
-    pub fn new(storage_directory: PathBuf, size_threshold: f64, cleanup_target: f64) -> Self {
-        debug!("Size threshold: {} bytes", size_threshold);
-        debug!("Cleanup target: {} bytes", cleanup_target);
-        Self {
-            storage_directory,
-            size_threshold,
-            cleanup_target,
-        }
+    pub fn new(size_threshold: f64) -> Self {
+        Self { size_threshold }
     }
 }

--- a/core/src/services/storage/jobs/metadata.rs
+++ b/core/src/services/storage/jobs/metadata.rs
@@ -1,0 +1,48 @@
+use super::super::Context;
+use crate::libraries::helpers::keys;
+use crate::libraries::scheduling::{Job, TaskManager};
+use crate::libraries::storage::FileMetadata;
+use crate::{
+    libraries::resources::{ResourceManager, ResourceManagerProvider},
+    with_redis_resource,
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use log::debug;
+use redis::AsyncCommands;
+
+#[derive(Clone)]
+pub struct MetadataJob {}
+
+#[async_trait]
+impl Job for MetadataJob {
+    type Context = Context;
+
+    const NAME: &'static str = module_path!();
+
+    async fn execute(&self, manager: TaskManager<Self::Context>) -> Result<()> {
+        let mut redis = with_redis_resource!(manager);
+        let storage_id = &manager.context.storage_id;
+        let storage = &manager.context.storage;
+
+        manager.ready().await;
+
+        loop {
+            let (_, raw_metadata): (String, String) = redis
+                .blpop(keys::storage::metadata::pending(storage_id), 0)
+                .await?;
+
+            let metadata: FileMetadata = serde_json::from_str(&raw_metadata)?;
+
+            debug!("Adding file from metadata queue: {}", raw_metadata);
+
+            storage.add_file(metadata).await?;
+        }
+    }
+}
+
+impl MetadataJob {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/core/src/services/storage/jobs/mod.rs
+++ b/core/src/services/storage/jobs/mod.rs
@@ -1,5 +1,7 @@
 mod cleanup;
+mod metadata;
 mod server;
 
 pub use cleanup::CleanupJob;
+pub use metadata::MetadataJob;
 pub use server::*;

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -33,7 +33,11 @@ All metadata is stored in a key-value in-memory database called [Redis](https://
 // SID = storage ID
 // PID = randomly generated ephemeral provider ID
 `storage:${SID}:${PID}:host` = string EX 60s	// (host + port)
+
+`storage:${SID}:metadata.pending` = List<FileMetadata>	// see below
 ```
+
+To optimise storage performance and reduce the need for database synchronization, metadata of newly created and modified files is not written to the storage database by the writing service directly. Instead, the relevant metadata is collected and appended to the `:metadata.pending` list. The corresponding storage service will then update its internal database with this information by continously watching this list and pulling new metadata.
 
 ### API
 ```javascript


### PR DESCRIPTION
### 🔧 Changes
When using a "slow" storage medium like a network filesystem, SQLite runs into issues with synchronising writes from many threads/processes/nodes. This is especially important when deploying to cloud providers where only a single storage backend is used.

This PR changes the storage handling so that sessions record a files metadata and send it to the storage service by putting it into a new `storage:<id>:metadata.pending` redis list. The storage service then fetches this and inserts it into the database. While this slightly reduces resilience in outage scenarios, it highly improves performance as next to no write synchronisation is required anymore.