### PR TITLE
Prevent session startup desync issue

### DIFF
--- a/core/src/libraries/helpers/mod.rs
+++ b/core/src/libraries/helpers/mod.rs
@@ -13,7 +13,7 @@ pub mod lua;
 
 pub use backoff::Backoff;
 pub use capabilities::*;
-pub use healthcheck::wait_for;
+pub use healthcheck::{wait_for, wait_for_key};
 pub use timeout::Timeout;
 
 /// Splits the input string into two parts at the first occurence of the separator


### PR DESCRIPTION
### 🔧 Changes
When a session node starts up, the manager continuously checks the `/status` endpoint which is forwarded through the nodes `proxy` service. In some very rare cases, this endpoint would be available and queried by the manager before the nodes heartbeat is alive.

This has two issues:
1. The HTTP based polling of the endpoint is expensive, relatively speaking
2. The proxy may not know about the session yet but the manager fulfils the creation request allowing the client to make requests using the session ID