### PR TITLE
Allow clients to set arbitrary session metadata

### DIFF
--- a/core/src/libraries/helpers/capabilities.rs
+++ b/core/src/libraries/helpers/capabilities.rs
@@ -78,10 +78,8 @@ pub struct CapabilitiesProxy {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct WebGridOptions {
-    /// Name for a session for later querying
-    pub name: Option<String>,
-    /// Build for a session for later querying
-    pub build: Option<String>,
+    /// Arbitrary metadata which can be set by the client and later fetched through the API.
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -111,7 +109,7 @@ pub struct Capabilities {
     #[serde(rename = "webgrid:options")]
     pub webgrid_options: Option<WebGridOptions>,
 
-    /// Additional capabilities that are not part of the W3C standard or added by WebGrid
+    /// Additional capabilities that are not part of the W3C standard or added by WebGrid.
     #[serde(flatten)]
     pub extension_capabilities: HashMap<String, Value>,
 }


### PR DESCRIPTION
### 🔧 Changes
This PR enables clients to set arbitrary key-value metadata on session creation through the `webgrid:options.metadata` capabilities extension and later modify or add values during runtime by setting cookies with the prefix `webgrid:metadata.session:<key>`.

The metadata can later be used at the API as a filter condition when querying for sessions or just simply retrieved.

As of now, this feature remains undocumented. However, it is expected that it will be amended by timed metadata later on and documentation will follow at that point.