### PR TITLE
Implement clean failure path for orchestrator

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -76,12 +76,12 @@ async fn main() -> Result<()> {
         Command::Orchestrator(core_options) => match core_options.provisioner {
             #[cfg(feature = "docker")]
             Provisioner::Docker(options) => {
-                provisioners::docker::run(shared_options, core_options.core, options).await
+                provisioners::docker::run(shared_options, core_options.core, options).await?
             }
 
             #[cfg(feature = "kubernetes")]
             Provisioner::Kubernetes(options) => {
-                provisioners::kubernetes::run(shared_options, core_options.core, options).await
+                provisioners::kubernetes::run(shared_options, core_options.core, options).await?
             }
         },
 

--- a/core/src/services/orchestrator/core/mod.rs
+++ b/core/src/services/orchestrator/core/mod.rs
@@ -1,5 +1,6 @@
 use super::super::SharedOptions;
 use crate::libraries::lifecycle::Heart;
+use anyhow::Result;
 use jatsl::{schedule, JobScheduler, StatusServer};
 use log::info;
 use structopt::StructOpt;
@@ -33,7 +34,7 @@ pub async fn start<P: Provisioner + Send + Sync + Clone + 'static>(
     provisioner: P,
     options: Options,
     shared_options: SharedOptions,
-) {
+) -> Result<()> {
     let (mut heart, _) = Heart::new();
 
     let context = Context::new(
@@ -69,4 +70,6 @@ pub async fn start<P: Provisioner + Send + Sync + Clone + 'static>(
     info!("Heart died: {}", death_reason);
 
     scheduler.terminate_jobs().await;
+
+    Ok(())
 }

--- a/core/src/services/orchestrator/core/provisioner.rs
+++ b/core/src/services/orchestrator/core/provisioner.rs
@@ -1,5 +1,5 @@
 use crate::libraries::helpers::{parse_browser_string, split_into_two, CapabilitiesRequest};
-
+use anyhow::Result;
 pub use async_trait::async_trait;
 use std::fmt;
 
@@ -17,8 +17,11 @@ pub struct ProvisionerCapabilities {
 #[async_trait]
 pub trait Provisioner {
     fn capabilities(&self) -> ProvisionerCapabilities;
-    async fn provision_node(&self, session_id: &str, capabilities: CapabilitiesRequest)
-        -> NodeInfo;
+    async fn provision_node(
+        &self,
+        session_id: &str,
+        capabilities: CapabilitiesRequest,
+    ) -> Result<NodeInfo>;
     async fn terminate_node(&self, session_id: &str);
 }
 

--- a/core/src/services/orchestrator/provisioners/docker/mod.rs
+++ b/core/src/services/orchestrator/provisioners/docker/mod.rs
@@ -1,5 +1,6 @@
 use super::super::super::SharedOptions;
 use crate::libraries::helpers::constants;
+use anyhow::Result;
 use structopt::StructOpt;
 
 mod provisioner;
@@ -21,11 +22,26 @@ pub struct Options {
     /// Example: "webgrid-node-firefox=firefox::68.7.0esr,webgrid-node-chrome=chrome::81.0.4044.122"
     #[structopt(long, env)]
     images: String,
+
+    /// Do not enable video recordings for spawned sessions
+    #[structopt(long, env)]
+    disable_recording: bool,
 }
 
-pub async fn run(shared_options: SharedOptions, core_options: CoreOptions, options: Options) {
+pub async fn run(
+    shared_options: SharedOptions,
+    core_options: CoreOptions,
+    options: Options,
+) -> Result<()> {
     let images = parse_images_string(options.images);
 
-    let provisioner = DockerProvisioner::new(options.node_port, images);
-    start(Type::Docker, provisioner, core_options, shared_options).await;
+    let provisioner = DockerProvisioner::new(
+        options.node_port,
+        images,
+        options.disable_recording,
+    )?;
+
+    start(Type::Docker, provisioner, core_options, shared_options).await?;
+
+    Ok(())
 }

--- a/core/src/services/orchestrator/provisioners/kubernetes/mod.rs
+++ b/core/src/services/orchestrator/provisioners/kubernetes/mod.rs
@@ -1,5 +1,6 @@
 use super::super::super::SharedOptions;
 use crate::libraries::helpers::constants;
+use anyhow::Result;
 use structopt::StructOpt;
 
 mod provisioner;
@@ -23,9 +24,15 @@ pub struct Options {
     images: String,
 }
 
-pub async fn run(shared_options: SharedOptions, core_options: CoreOptions, options: Options) {
+pub async fn run(
+    shared_options: SharedOptions,
+    core_options: CoreOptions,
+    options: Options,
+) -> Result<()> {
     let images = parse_images_string(options.images);
 
     let provisioner = K8sProvisioner::new(options.node_port, images).await;
-    start(Type::K8s, provisioner, core_options, shared_options).await;
+    start(Type::K8s, provisioner, core_options, shared_options).await?;
+
+    Ok(())
 }


### PR DESCRIPTION
### 🔧 Changes
Previously, there was next to no error handling in the orchestrator. Either it worked, or it crashed. Especially when working with infrastructure, this is less than ideal (mildly put). As a first step on the road to improvement, this PR adds basic error handling in the orchestrator and provisioners by catching any errors that are thrown for later processing.

Note: This commit introduces formatting inconsistencies (causing the validation pipeline to fail) since it has been split off from a larger change-set. These will be rectified in a future commit that contains the remaining changes. Yes, I am lazy for once. Deal with it.