### PR TITLE
Implement basic OpenTelemetry tracing support

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -72,6 +72,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "async-stream"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a26cb53174ddd320edfff199a853f93d571f48eeb4dde75e67a9a3dbb7b7e5e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db134ba52475c060f3329a8ef0f8786d6b872ed01515d4b79c162e5798da1340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +511,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fnv"
@@ -926,6 +953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "multipart"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1419,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91cea1dfd50064e52db033179952d18c770cbc5dfefc8eba45d619357ba3914"
+dependencies = [
+ "async-trait",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.8.3",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba72bd27f28377a2e4f0f15a040c06ab0e70ea73df0689f8adf4d22d04591a1a"
+dependencies = [
+ "async-trait",
+ "http",
+ "opentelemetry",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c19adec09e1d86bdc72cbc2dea6d7276d90d6d50ad430842446382a4ef440b"
+dependencies = [
+ "async-trait",
+ "futures",
+ "opentelemetry",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee3a8db5ab73cceebcf248ed0cdc992f2ed507dc430dae7f3c8eab7c55c13a3"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1523,16 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project"
@@ -1524,6 +1631,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -2375,6 +2533,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556dc31b450f45d18279cfc3d2519280273f460d5387e6b7b24503e65d206f8b"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,8 +2581,12 @@ checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project",
+ "rand 0.8.3",
+ "slab",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tower-layer",
  "tower-service",
@@ -2433,6 +2636,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -2726,6 +2939,10 @@ dependencies = [
  "kube-derive",
  "lazy_static",
  "log",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "pretty_env_logger",
  "rand 0.8.3",
  "redis",
@@ -2740,6 +2957,16 @@ dependencies = [
  "tokio",
  "uuid",
  "warp",
+]
+
+[[package]]
+name = "which"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+dependencies = [
+ "either",
+ "libc",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,6 +26,12 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "0.8", features = ["v4"] }
 jatsl = "0.1.0"
 
+# Tracing
+opentelemetry = { version = "0.13.0", features = ["rt-tokio"] }
+opentelemetry-otlp = "0.6.0"
+opentelemetry-semantic-conventions = "0.5.0"
+opentelemetry-http = "0.2.0"
+
 # API
 juniper = { git = "https://github.com/TilBlechschmidt/juniper", branch = "patch-1", optional = true, features = ["expose-test-schema"] }
 juniper_warp = { git = "https://github.com/TilBlechschmidt/juniper", branch = "patch-1", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,10 +27,10 @@ uuid = { version = "0.8", features = ["v4"] }
 jatsl = "0.1.0"
 
 # Tracing
-opentelemetry = { version = "0.13.0", features = ["rt-tokio"] }
-opentelemetry-otlp = "0.6.0"
-opentelemetry-semantic-conventions = "0.5.0"
-opentelemetry-http = "0.2.0"
+opentelemetry = { version = "0.13", features = ["rt-tokio"] }
+opentelemetry-otlp = "0.6"
+opentelemetry-semantic-conventions = "0.5"
+opentelemetry-http = "0.2"
 
 # API
 juniper = { git = "https://github.com/TilBlechschmidt/juniper", branch = "patch-1", optional = true, features = ["expose-test-schema"] }

--- a/core/src/libraries/helpers/keys.rs
+++ b/core/src/libraries/helpers/keys.rs
@@ -135,6 +135,14 @@ pub mod session {
         format!("{}:storage", session_prefix(session_id))
     }
 
+    pub mod telemetry {
+        use super::session_prefix;
+
+        pub fn creation(session_id: &str) -> String {
+            format!("{}:telemetry.creation", session_prefix(session_id))
+        }
+    }
+
     pub mod heartbeat {
         use super::session_prefix;
 

--- a/core/src/libraries/helpers/lua.rs
+++ b/core/src/libraries/helpers/lua.rs
@@ -62,6 +62,8 @@ pub fn delete_session() -> String {
     redis.call('DEL', 'session:' .. sessionID .. ':downstream')
     
     redis.call('DEL', 'session:' .. sessionID .. ':storage')
+
+    redis.call('DEL', 'session:' .. sessionID .. ':telemetry.creation')
     "
     .to_string()
 }

--- a/core/src/libraries/mod.rs
+++ b/core/src/libraries/mod.rs
@@ -10,6 +10,7 @@ pub mod metrics;
 pub mod recording;
 pub mod resources;
 pub mod storage;
+pub mod tracing;
 
 // TODO: Implement proper testing :)
 // #[cfg(test)]

--- a/core/src/libraries/tracing/constants.rs
+++ b/core/src/libraries/tracing/constants.rs
@@ -1,0 +1,24 @@
+pub mod service {
+    pub const NAMESPACE: &str = "Webgrid";
+
+    pub const PROXY: &str = "Proxy";
+    pub const MANAGER: &str = "Manager";
+    pub const ORCHESTRATOR: &str = "Orchestrator";
+    pub const STORAGE: &str = "Storage";
+    pub const NODE: &str = "Node";
+    pub const API: &str = "API";
+}
+
+pub mod trace {
+    use opentelemetry::Key;
+
+    pub const NET_UPSTREAM_NAME: Key = Key::from_static_str("net.upstream.name");
+
+    pub const SESSION_ID: Key = Key::from_static_str("webgrid.session.id");
+    pub const SESSION_ORCHESTRATOR: Key = Key::from_static_str("webgrid.session.orchestrator");
+    pub const SESSION_HOST: Key = Key::from_static_str("webgrid.session.host");
+    pub const SESSION_CONTAINER_IMAGE: Key =
+        Key::from_static_str("webgrid.session.container.image");
+    pub const SESSION_CONTAINER_NAME: Key = Key::from_static_str("webgrid.session.container.name");
+    pub const SESSION_ID_INTERNAL: Key = Key::from_static_str("webgrid.session.id.internal");
+}

--- a/core/src/libraries/tracing/init.rs
+++ b/core/src/libraries/tracing/init.rs
@@ -1,0 +1,57 @@
+use std::time::Duration;
+
+use opentelemetry::{
+    global,
+    sdk::{
+        propagation::TraceContextPropagator,
+        trace::{self, IdGenerator, Sampler},
+        Resource,
+    },
+    trace::TraceError,
+    KeyValue,
+};
+use opentelemetry_otlp::Protocol;
+use opentelemetry_semantic_conventions as semcov;
+
+use crate::libraries::tracing::constants;
+
+pub fn init<T>(
+    endpoint: &Option<String>,
+    service: T,
+    instance_id: Option<T>,
+) -> Result<(), TraceError>
+where
+    T: Into<String>,
+{
+    if let Some(endpoint) = endpoint {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+
+        let mut resource: Vec<KeyValue> = vec![
+            semcov::resource::SERVICE_NAME.string(service.into()),
+            semcov::resource::SERVICE_NAMESPACE.string(constants::service::NAMESPACE),
+            semcov::resource::SERVICE_VERSION.string(env!("WEBGRID_VERSION")),
+        ];
+
+        if let Some(instance_id) = instance_id {
+            resource.push(semcov::resource::SERVICE_INSTANCE_ID.string(instance_id.into()));
+        }
+
+        opentelemetry_otlp::new_pipeline()
+            .with_endpoint(endpoint)
+            .with_protocol(Protocol::Grpc)
+            .with_timeout(Duration::from_secs(3))
+            .with_trace_config(
+                trace::config()
+                    .with_sampler(Sampler::AlwaysOn)
+                    .with_id_generator(IdGenerator::default())
+                    .with_max_events_per_span(64)
+                    .with_max_attributes_per_span(16)
+                    .with_max_events_per_span(16)
+                    .with_resource(Resource::new(resource)),
+            )
+            .with_tonic()
+            .install_batch(opentelemetry::runtime::Tokio)?;
+    }
+
+    Ok(())
+}

--- a/core/src/libraries/tracing/mod.rs
+++ b/core/src/libraries/tracing/mod.rs
@@ -1,0 +1,16 @@
+//! Tracing module
+//!
+//! This module contains all the tools necessary to enable tracing in conformance with OpenTelemetry.
+
+pub mod constants;
+mod init;
+mod propagation;
+
+pub use init::init;
+pub use propagation::StringPropagator;
+
+use opentelemetry::global::{self, BoxedTracer};
+
+pub fn global_tracer() -> BoxedTracer {
+    global::tracer("webgrid.dev/main")
+}

--- a/core/src/libraries/tracing/propagation.rs
+++ b/core/src/libraries/tracing/propagation.rs
@@ -1,0 +1,32 @@
+use super::global_tracer;
+use opentelemetry::{
+    global::{self, BoxedSpan},
+    trace::Tracer,
+    Context,
+};
+use std::collections::HashMap;
+
+pub struct StringPropagator;
+
+impl StringPropagator {
+    pub fn serialize(context: &Context) -> Result<String, serde_json::Error> {
+        let mut map = HashMap::new();
+
+        global::get_text_map_propagator(|propagator| propagator.inject_context(context, &mut map));
+
+        serde_json::to_string(&map)
+    }
+
+    pub fn deserialize(serialized_context: &str, span_name: &str) -> BoxedSpan {
+        if let Ok(deserialized) =
+            serde_json::from_str::<HashMap<String, String>>(serialized_context)
+        {
+            let parent_cx =
+                global::get_text_map_propagator(|propagator| propagator.extract(&deserialized));
+
+            global_tracer().start_with_context(span_name, parent_cx)
+        } else {
+            global_tracer().start(span_name)
+        }
+    }
+}

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use opentelemetry::global;
 use structopt::StructOpt;
 
 #[cfg(feature = "orchestrator")]
@@ -91,6 +92,8 @@ async fn main() -> Result<()> {
         #[cfg(feature = "api")]
         Command::Api(options) => api::run(shared_options, options).await?,
     }
+
+    global::shutdown_tracer_provider();
 
     Ok(())
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
         Command::Metrics(options) => metrics::run(shared_options, options).await,
 
         #[cfg(feature = "manager")]
-        Command::Manager(options) => manager::run(shared_options, options).await,
+        Command::Manager(options) => manager::run(shared_options, options).await?,
 
         #[cfg(feature = "node")]
         Command::Node(options) => node::run(shared_options, options).await?,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
         Command::Node(options) => node::run(shared_options, options).await?,
 
         #[cfg(feature = "proxy")]
-        Command::Proxy(options) => proxy::run(shared_options, options).await,
+        Command::Proxy(options) => proxy::run(shared_options, options).await?,
 
         #[cfg(feature = "storage")]
         Command::Storage(options) => storage::run(shared_options, options).await?,

--- a/core/src/services/manager/context.rs
+++ b/core/src/services/manager/context.rs
@@ -1,6 +1,7 @@
 use crate::libraries::{helpers::keys, lifecycle::BeatValue};
 use crate::libraries::{lifecycle::HeartBeat, resources::ResourceManagerProvider};
 use crate::libraries::{metrics::MetricsProcessor, resources::DefaultResourceManager};
+use opentelemetry::Context as TelemetryContext;
 use std::ops::Deref;
 
 #[derive(Clone)]
@@ -34,6 +35,7 @@ pub struct SessionCreationContext {
     pub remote_addr: String,
     pub user_agent: String,
     pub capabilities: String,
+    pub telemetry_context: TelemetryContext,
 }
 
 impl SessionCreationContext {
@@ -42,12 +44,14 @@ impl SessionCreationContext {
         remote_addr: String,
         user_agent: String,
         capabilities: String,
+        telemetry_context: TelemetryContext,
     ) -> Self {
         Self {
             context,
             remote_addr,
             user_agent,
             capabilities,
+            telemetry_context,
         }
     }
 }

--- a/core/src/services/node/tasks/driver.rs
+++ b/core/src/services/node/tasks/driver.rs
@@ -1,14 +1,24 @@
 use super::super::{structs::NodeError, Context};
-use crate::libraries::helpers::{wait_for, Timeout};
-use crate::libraries::lifecycle::logging::{LogCode, SessionLogger};
 use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
+use crate::libraries::{
+    lifecycle::logging::{LogCode, SessionLogger},
+    tracing::global_tracer,
+};
 use crate::with_redis_resource;
+use crate::{
+    libraries::helpers::{wait_for, Timeout},
+    services::node::context::StartupContext,
+};
 use jatsl::TaskManager;
 use log::{error, info};
+use opentelemetry::{
+    trace::{FutureExt, Span, TraceContextExt, Tracer},
+    Context as TelemetryContext,
+};
 use redis::{aio::ConnectionLike, AsyncCommands};
 use std::io::Error as IOError;
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
@@ -27,23 +37,30 @@ impl DriverReference {
     }
 }
 
-pub async fn start_driver(manager: TaskManager<Context>) -> Result<(), NodeError> {
+pub async fn start_driver(manager: TaskManager<StartupContext>) -> Result<(), NodeError> {
+    let span = global_tracer()
+        .start_with_context("Start driver", manager.context.telemetry_context.clone());
+
     let mut con = with_redis_resource!(manager);
     let startup_timeout = Timeout::DriverStartup.get(&mut con).await;
-    let driver = manager.context.options.driver;
+    let driver = &manager.context.options.driver;
     let driver_port = manager.context.options.driver_port;
-    let browser = manager.context.options.browser;
+    let browser = &manager.context.options.browser;
 
     let mut logger = SessionLogger::new(con, "node".to_string(), manager.context.id.clone());
 
     logger.log(LogCode::DStart, None).await.ok();
 
     // Spawn the driver
+    span.add_event("Spawning process".to_string(), vec![]);
     let child = subtasks::launch_driver(&mut logger, driver, browser).await?;
     *manager.context.driver_reference.driver.lock().await = Some(child);
 
     // Await its startup
-    subtasks::await_driver_startup(startup_timeout, driver_port, &mut logger).await?;
+    let telemetry_context = TelemetryContext::current_with_span(span);
+    subtasks::await_driver_startup(startup_timeout, driver_port, &mut logger)
+        .with_context(telemetry_context)
+        .await?;
     logger.log(LogCode::DAlive, None).await.ok();
 
     Ok(())
@@ -62,15 +79,17 @@ pub async fn stop_driver(manager: TaskManager<Context>) -> Result<(), IOError> {
 }
 
 mod subtasks {
+    use opentelemetry::trace::StatusCode;
+
     use super::*;
 
     pub async fn launch_driver<C: ConnectionLike + AsyncCommands>(
         logger: &mut SessionLogger<C>,
-        driver: PathBuf,
-        browser: String,
+        driver: &Path,
+        browser: &str,
     ) -> Result<Child, NodeError> {
         // Chrome and safari need some "special handling"
-        let res = match browser.as_str() {
+        let res = match browser {
             "chrome" => Command::new(driver)
                 .arg("--whitelisted-ips")
                 .arg("*")
@@ -79,7 +98,6 @@ mod subtasks {
             "safari" => Command::new(driver)
                 .arg("--diagnose")
                 .arg("-p")
-                .arg("9998")
                 .stdout(Stdio::inherit())
                 .spawn(),
             _ => Command::new(driver).stdout(Stdio::inherit()).spawn(),
@@ -104,12 +122,17 @@ mod subtasks {
         driver_port: u16,
         logger: &mut SessionLogger<C>,
     ) -> Result<(), NodeError> {
+        let span = global_tracer().start("Awaiting driver startup");
         info!("Awaiting driver startup");
 
         let socket_addr: SocketAddr = ([127, 0, 0, 1], driver_port).into();
         let url = format!("http://{}/status", socket_addr);
+        let telemetry_context = TelemetryContext::current_with_span(span);
 
-        match wait_for(&url, Duration::from_secs(timeout as u64)).await {
+        match wait_for(&url, Duration::from_secs(timeout as u64))
+            .with_context(telemetry_context.clone())
+            .await
+        {
             Ok(_) => {
                 info!("Driver became responsive");
                 Ok(())
@@ -117,6 +140,10 @@ mod subtasks {
             Err(_) => {
                 error!("Timeout waiting for driver startup");
                 logger.log(LogCode::DTimeout, None).await.ok();
+                telemetry_context.span().set_status(
+                    StatusCode::Error,
+                    "Timeout waiting for driver startup".to_string(),
+                );
 
                 Err(NodeError::NoDriverResponse)
             }

--- a/core/src/services/node/tasks/init_service.rs
+++ b/core/src/services/node/tasks/init_service.rs
@@ -1,27 +1,41 @@
-use super::super::{structs::NodeError, Context};
-use crate::libraries::helpers::{keys, Timeout};
-use crate::libraries::lifecycle::{
-    logging::{LogCode, SessionLogger},
-    Heart, HeartStone,
-};
+use super::super::structs::NodeError;
 use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
 use crate::libraries::storage::StorageHandler;
+use crate::libraries::{
+    lifecycle::{
+        logging::{LogCode, SessionLogger},
+        Heart, HeartStone,
+    },
+    tracing::global_tracer,
+};
 use crate::with_redis_resource;
+use crate::{
+    libraries::helpers::{keys, Timeout},
+    services::node::context::StartupContext,
+};
 use jatsl::TaskManager;
 use log::error;
+use opentelemetry::trace::{Span, Tracer};
 use redis::AsyncCommands;
 use std::time::Duration;
 
 pub async fn initialize_service(
-    manager: TaskManager<Context>,
+    manager: TaskManager<StartupContext>,
 ) -> Result<(Heart, HeartStone), NodeError> {
     let mut con = with_redis_resource!(manager);
+
+    let span = global_tracer().start_with_context(
+        "Initialize service",
+        manager.context.telemetry_context.clone(),
+    );
 
     let (heart, heart_stone) = Heart::with_lifetime(Duration::from_secs(
         Timeout::SessionTermination.get(&mut con).await as u64,
     ));
 
-    if let Some(storage_directory) = manager.context.options.storage_directory {
+    if let Some(storage_directory) = &manager.context.options.storage_directory {
+        span.add_event("Load storage information".to_string(), vec![]);
+
         let storage_id = StorageHandler::storage_id(&storage_directory)
             .await
             .map_err(|e| {

--- a/core/src/services/node/tasks/init_tracing.rs
+++ b/core/src/services/node/tasks/init_tracing.rs
@@ -1,0 +1,31 @@
+use super::super::{structs::NodeError, Context};
+use crate::libraries::{
+    helpers::keys,
+    resources::{ResourceManager, ResourceManagerProvider},
+    tracing::StringPropagator,
+};
+use crate::with_redis_resource;
+use jatsl::TaskManager;
+use opentelemetry::{trace::TraceContextExt, Context as TelemetryContext};
+use redis::AsyncCommands;
+
+pub async fn initialize_tracing(
+    manager: TaskManager<Context>,
+) -> Result<TelemetryContext, NodeError> {
+    let mut con = with_redis_resource!(manager);
+
+    let raw_telemetry_context: String = con
+        .hget(
+            keys::session::telemetry::creation(&manager.context.id),
+            "context",
+        )
+        .await
+        .unwrap_or_default();
+
+    let telemetry_context = TelemetryContext::current_with_span(StringPropagator::deserialize(
+        &raw_telemetry_context,
+        "Node startup",
+    ));
+
+    Ok(telemetry_context)
+}

--- a/core/src/services/node/tasks/mod.rs
+++ b/core/src/services/node/tasks/mod.rs
@@ -1,11 +1,13 @@
 mod driver;
 mod init_service;
 mod init_session;
+mod init_tracing;
 mod log_exit;
 mod terminate;
 
 pub use driver::{start_driver, stop_driver, DriverReference};
 pub use init_service::initialize_service;
 pub use init_session::initialize_session;
+pub use init_tracing::initialize_tracing;
 pub use log_exit::log_exit;
 pub use terminate::terminate;

--- a/core/src/services/options.rs
+++ b/core/src/services/options.rs
@@ -31,4 +31,10 @@ pub struct SharedOptions {
         value_name = "level"
     )]
     pub log: String,
+
+    /// OpenTelemetry collector endpoint
+    ///
+    /// Omitting it disables tracing
+    #[structopt(long, global = true, env)]
+    pub trace_endpoint: Option<String>,
 }

--- a/core/src/services/orchestrator/core/jobs/processor.rs
+++ b/core/src/services/orchestrator/core/jobs/processor.rs
@@ -1,13 +1,23 @@
 use super::super::Context;
-use crate::libraries::lifecycle::logging::{LogCode, Logger};
-use crate::libraries::resources::{ResourceManager, ResourceManagerProvider};
-use crate::libraries::{helpers::keys, resources::RedisResource};
+use crate::libraries::helpers::keys;
+use crate::libraries::{
+    lifecycle::logging::{LogCode, Logger},
+    resources::RedisResource,
+};
+use crate::libraries::{
+    resources::{ResourceManager, ResourceManagerProvider},
+    tracing::StringPropagator,
+};
 use crate::with_redis_resource;
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::offset::Utc;
 use jatsl::{Job, TaskManager};
 use log::{debug, info};
+use opentelemetry::{
+    trace::{FutureExt, StatusCode, TraceContextExt},
+    Context as TelemetryContext,
+};
 use redis::{aio::Connection, AsyncCommands, RedisResult};
 
 #[derive(Clone)]
@@ -33,9 +43,24 @@ impl Job for ProcessorJob {
                 .lindex::<_, String>(keys::orchestrator::pending(&orchestrator_id), -1)
                 .await
             {
-                // Run the scheduling process
-                match ProcessorJob::schedule_session(session_id.clone(), &mut con, &manager.context)
+                // Retrieve telemetry context
+                let raw_telemetry_context: String = con
+                    .hget(keys::session::telemetry::creation(&session_id), "context")
                     .await
+                    .unwrap_or_default();
+
+                let telemetry_context = TelemetryContext::current_with_span(
+                    StringPropagator::deserialize(&raw_telemetry_context, "Provision node"),
+                );
+
+                // Run the scheduling process
+                match ProcessorJob::schedule_session(
+                    session_id.clone(),
+                    &mut con,
+                    &manager.context,
+                    telemetry_context.clone(),
+                )
+                .await
                 {
                     Ok(node_info) => {
                         debug!("Provisioned node {} {:?}", session_id, node_info);
@@ -43,6 +68,9 @@ impl Job for ProcessorJob {
                     }
                     Err(e) => {
                         debug!("Failed to provision node {} {:?}", session_id, e);
+                        telemetry_context
+                            .span()
+                            .set_status(StatusCode::Error, e.to_string());
                         logger.log(&session_id, LogCode::StartFail, None).await.ok();
                         manager
                             .context
@@ -77,8 +105,10 @@ impl ProcessorJob {
         session_id: String,
         con: &mut RedisResource<Connection>,
         context: &Context,
+        telemetry_context: TelemetryContext,
     ) -> Result<()> {
         let orchestrator_id = context.id.clone();
+        let span = telemetry_context.span();
         info!("Starting job {}", session_id);
 
         // TODO Look if the job is too old
@@ -90,11 +120,18 @@ impl ProcessorJob {
             .unwrap();
         let capabilities_request = serde_json::from_str(&raw_capabilities_request).unwrap();
 
+        span.add_event("Delegating to provisioner".to_string(), vec![]);
+
         // TODO Add possible failure path to provisioner
         let info_future = context
             .provisioner
-            .provision_node(&session_id, capabilities_request);
+            .provision_node(&session_id, capabilities_request)
+            .with_context(telemetry_context.clone());
         let node_info = info_future.await?;
+
+        span.add_event("Persist node info".to_string(), vec![]);
+
+        // TODO Add node info to span
 
         redis::pipe()
             .atomic()

--- a/core/src/services/orchestrator/provisioners/docker/mod.rs
+++ b/core/src/services/orchestrator/provisioners/docker/mod.rs
@@ -38,6 +38,7 @@ pub async fn run(
     let provisioner = DockerProvisioner::new(
         options.node_port,
         images,
+        shared_options.trace_endpoint.clone(),
         options.disable_recording,
     )?;
 

--- a/core/src/services/proxy/mod.rs
+++ b/core/src/services/proxy/mod.rs
@@ -1,8 +1,12 @@
 //! Unified grid entrypoint provider
 
 use super::SharedOptions;
-use crate::libraries::helpers::constants;
 use crate::libraries::lifecycle::Heart;
+use crate::libraries::{
+    helpers::constants,
+    tracing::{self, constants::service},
+};
+use anyhow::Result;
 use jatsl::{schedule, JobScheduler, StatusServer};
 use log::info;
 use structopt::StructOpt;
@@ -24,7 +28,9 @@ pub struct Options {
     port: u16,
 }
 
-pub async fn run(shared_options: SharedOptions, options: Options) {
+pub async fn run(shared_options: SharedOptions, options: Options) -> Result<()> {
+    tracing::init(&shared_options.trace_endpoint, service::PROXY, None)?;
+
     let (mut heart, _) = Heart::new();
 
     let context = Context::new(shared_options.redis);
@@ -46,4 +52,6 @@ pub async fn run(shared_options: SharedOptions, options: Options) {
     info!("Heart died: {}", death_reason);
 
     scheduler.terminate_jobs().await;
+
+    Ok(())
 }

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-proxy
-    command: proxy --log debug,hyper=warn
+    command: proxy --log debug,hyper=warn,warp=warn,sqlx=warn,tower=warn,h2=warn --trace-endpoint http://webgrid-otelcol:4317
     ports:
       - 8080:40005
     depends_on:
@@ -13,14 +13,14 @@ services:
     image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-manager
-    command: manager example-manager webgrid-manager --log debug,hyper=warn
+    command: manager example-manager webgrid-manager --log debug,hyper=warn,warp=warn,sqlx=warn,tower=warn,h2=warn --trace-endpoint http://webgrid-otelcol:4317
     depends_on:
       - redis
   orchestrator:
     image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-orchestrator
-    command: orchestrator --slot-count 5 example-orchestrator docker --images "${REPOSITORY:-webgrid}/node-firefox:${IMAGE_TAG:-latest}=firefox::68.7.0esr,${REPOSITORY:-webgrid}/node-chrome:${IMAGE_TAG:-latest}=chrome::81.0.4044.122" --log debug,hyper=warn
+    command: orchestrator --slot-count 5 example-orchestrator docker --images "${REPOSITORY:-webgrid}/node-firefox:${IMAGE_TAG:-latest}=firefox::68.7.0esr,${REPOSITORY:-webgrid}/node-chrome:${IMAGE_TAG:-latest}=chrome::81.0.4044.122" --log debug,hyper=warn,warp=warn,sqlx=warn,tower=warn,h2=warn --trace-endpoint http://webgrid-otelcol:4317 ${ORCHESTRATOR_FLAGS:-}
     depends_on:
       - redis
     volumes:
@@ -29,7 +29,7 @@ services:
     image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-storage
-    command: storage --log debug,hyper=warn --host webgrid-storage --storage-directory /storage --size-limit 10
+    command: storage --log debug,hyper=warn,warp=warn,sqlx=warn,tower=warn,h2=warn --trace-endpoint http://webgrid-otelcol:4317 --host webgrid-storage --storage-directory /storage --size-limit 10
     depends_on:
       - redis
     volumes:
@@ -38,20 +38,20 @@ services:
     image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-gc
-    command: gc --log debug
+    command: gc --log debug,hyper=warn,warp=warn,sqlx=warn,tower=warn,h2=warn --trace-endpoint http://webgrid-otelcol:4317
     depends_on:
       - redis
   api:
     image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-api
-    command: api --log debug,hyper=warn --host webgrid-api
+    command: api --log debug,hyper=warn,warp=warn,sqlx=warn,tower=warn,h2=warn --trace-endpoint http://webgrid-otelcol:4317 --host webgrid-api
     depends_on:
       - redis
   redis:
     image: redis:6.2-alpine
     container_name: webgrid-redis
-    command: redis-server --notify-keyspace-events Kgx
+    command: redis-server --notify-keyspace-events Kgx --save "" --appendonly no
     ports:
       - 6379:6379
 volumes:
@@ -60,5 +60,5 @@ volumes:
 
 networks:
   default:
-    external:
-      name: webgrid
+    external: true
+    name: webgrid

--- a/distribution/kubernetes/chart/templates/_helpers.tpl
+++ b/distribution/kubernetes/chart/templates/_helpers.tpl
@@ -89,3 +89,14 @@ Allow customization of the image tag used
 {{- define "web-grid.imageTag" -}}
 {{- default .Chart.AppVersion .Values.image.tag }}
 {{- end }}
+
+{{/*
+Create the name of the telemetry endpoint
+*/}}
+{{- define "web-grid.telemetryEndpoint" -}}
+{{- if .Values.telemetry.demo }}
+{{- printf "https://%s-telemetry:4317" (include "web-grid.fullname" .) }}
+{{- else }}
+{{ .Values.telemetry.endpoint }}
+{{- end }}
+{{- end }}

--- a/distribution/kubernetes/chart/templates/api.yaml
+++ b/distribution/kubernetes/chart/templates/api.yaml
@@ -58,6 +58,10 @@ spec:
                   fieldPath: metadata.name
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
+            {{- if .Values.telemetry.enabled }}
+            - name: TRACE_ENDPOINT
+              value: {{ include "web-grid.telemetryEndpoint" . }}
+            {{- end}}
           livenessProbe:
             tcpSocket:
               port: status

--- a/distribution/kubernetes/chart/templates/configMap.yaml
+++ b/distribution/kubernetes/chart/templates/configMap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "web-grid.fullname" . }}-redis
   labels:
-      web-grid/component: orchestrator
+      web-grid/component: redis
       {{- include "web-grid.labels" . | nindent 6 }}
 data:
   # ------- TODO Replace maxmemory with calculated value! -------
@@ -95,6 +95,10 @@ data:
                 - name: STORAGE_DIRECTORY
                   value: "/storage"
                 {{- end }}
+                {{- if .Values.telemetry.enabled }}
+                - name: TRACE_ENDPOINT
+                  value: {{ include "web-grid.telemetryEndpoint" . }}
+                {{- end}}
                 - name: CRF
                   value: "{{ .Values.recording.quality.crf }}"
                 - name: MAX_BITRATE

--- a/distribution/kubernetes/chart/templates/manager.yaml
+++ b/distribution/kubernetes/chart/templates/manager.yaml
@@ -58,6 +58,10 @@ spec:
                   fieldPath: metadata.name
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
+            {{- if .Values.telemetry.enabled }}
+            - name: TRACE_ENDPOINT
+              value: {{ include "web-grid.telemetryEndpoint" . }}
+            {{- end}}
           livenessProbe:
             tcpSocket:
               port: status

--- a/distribution/kubernetes/chart/templates/metrics.yaml
+++ b/distribution/kubernetes/chart/templates/metrics.yaml
@@ -53,6 +53,10 @@ spec:
               value: "{{ include "web-grid.redisURL" . }}"
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
+            {{- if .Values.telemetry.enabled }}
+            - name: TRACE_ENDPOINT
+              value: {{ include "web-grid.telemetryEndpoint" . }}
+            {{- end}}
           livenessProbe:
             tcpSocket:
               port: status

--- a/distribution/kubernetes/chart/templates/orchestrator.yaml
+++ b/distribution/kubernetes/chart/templates/orchestrator.yaml
@@ -71,6 +71,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.telemetry.enabled }}
+            - name: TRACE_ENDPOINT
+              value: {{ include "web-grid.telemetryEndpoint" . }}
+            {{- end}}
           livenessProbe:
             tcpSocket:
               port: status

--- a/distribution/kubernetes/chart/templates/proxy.yaml
+++ b/distribution/kubernetes/chart/templates/proxy.yaml
@@ -50,6 +50,10 @@ spec:
               value: "{{ include "web-grid.redisURL" . }}"
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
+            {{- if .Values.telemetry.enabled }}
+            - name: TRACE_ENDPOINT
+              value: {{ include "web-grid.telemetryEndpoint" . }}
+            {{- end}}
           livenessProbe:
             tcpSocket:
               port: status

--- a/distribution/kubernetes/chart/templates/redis.yaml
+++ b/distribution/kubernetes/chart/templates/redis.yaml
@@ -96,6 +96,10 @@ spec:
               value: {{ .Values.logLevel }}
             - name: SESSION_RETENTION_DURATION
               value: "{{ .Values.config.garbageCollector.retentionDuration }}"
+            {{- if .Values.telemetry.enabled }}
+            - name: TRACE_ENDPOINT
+              value: {{ include "web-grid.telemetryEndpoint" . }}
+            {{- end}}
           livenessProbe:
             tcpSocket:
               port: status

--- a/distribution/kubernetes/chart/templates/storage.yaml
+++ b/distribution/kubernetes/chart/templates/storage.yaml
@@ -80,6 +80,10 @@ spec:
                   fieldPath: status.podIP
             - name: STORAGE_DIRECTORY
               value: "/storage"
+            {{- if .Values.telemetry.enabled }}
+            - name: TRACE_ENDPOINT
+              value: {{ include "web-grid.telemetryEndpoint" . }}
+            {{- end}}
           livenessProbe:
             tcpSocket:
               port: status

--- a/distribution/kubernetes/chart/templates/telemetryDemo.yaml
+++ b/distribution/kubernetes/chart/templates/telemetryDemo.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.telemetry.demo }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "web-grid.fullname" . }}-telemetry
+  labels:
+      {{- include "web-grid.labels" . | nindent 6 }}
+data:
+  otel.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+
+    exporters:
+      logging:
+          loglevel: debug
+
+      jaeger:
+          endpoint: localhost:14250
+          insecure: true
+
+    processors:
+      batch:
+
+    extensions:
+      health_check:
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [logging, jaeger]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [logging]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "web-grid.fullname" . }}-telemetry
+  labels:
+    {{- include "web-grid.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "web-grid.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "web-grid.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.nodeSelector.telemetryDemo }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity.telemetryDemo }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations.telemetryDemo }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: otel-config
+          configMap:
+            name: {{ include "web-grid.fullname" . }}-telemetry
+      containers:
+        - image: otel/opentelemetry-collector-dev:latest
+          imagePullPolicy: IfNotPresent
+          name: {{ .Chart.Name }}-otelcol
+          args: ['--config=/config/otel.yaml']
+          ports:
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: status
+              containerPort: 13133
+              protocol: TCP
+          volumeMounts:
+            - name: otel-config
+              mountPath: /config
+          livenessProbe:
+            tcpSocket:
+              port: status
+          resources:
+            {{- toYaml .Values.resources.telemetryDemo | nindent 12 }}
+        - image: jaegertracing/all-in-one:latest
+          name: {{ .Chart.Name }}-jaeger
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: jaeger-ui
+              containerPort: 16686
+              protocol: TCP
+            - name: data-ingress
+              containerPort: 14250
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources.telemetryDemo | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "web-grid.fullname" . }}-telemetry
+  labels:
+    {{- include "web-grid.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 16686
+      targetPort: jaeger-ui
+      protocol: TCP
+      name: jaeger-ui
+  selector:
+    {{- include "web-grid.selectorLabels" . | nindent 4 }}
+{{- end}}

--- a/distribution/kubernetes/chart/values.yaml
+++ b/distribution/kubernetes/chart/values.yaml
@@ -2,7 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-logLevel: debug,hyper=warn,warp=warn,sqlx=warn
+logLevel: debug,hyper=warn,warp=warn,sqlx=warn,tower=warn,h2=warn
+
+service:
+  type: ClusterIP
+  port: 80
 
 config:
   orchestrator:
@@ -32,6 +36,15 @@ recording:
     #
     # Note: The storage class needs to support concurrent access by multiple pods! (e.g. a hostPath based PV)
     storageClassName: local-path
+
+telemetry:
+  # Whether request traces should be collected
+  enabled: false
+  # OpenTelemetry collector gRPC endpoint where traces are pushed to.
+  endpoint: ""
+  # Whether to deploy a OpenTelemetry collector and Jaeger "all-in-one" demo. Overwrites the endpoint.
+  # NOTE: This is intended for demonstration purposes ONLY and may impact performance when used in production!
+  demo: false
 
 replicaCount:
   proxy: 1
@@ -73,6 +86,7 @@ resources:
     requests:
       cpu: '1'
       memory: 3000Mi
+  telemetryDemo: {}
 
 nodeSelector:
   redis: {}
@@ -83,6 +97,7 @@ nodeSelector:
   session: {}
   storage: {}
   api: {}
+  telemetryDemo: {}
 
 tolerations:
   redis: []
@@ -93,6 +108,7 @@ tolerations:
   session: []
   storage: []
   api: []
+  telemetryDemo: []
 
 affinity:
   redis: {}
@@ -103,7 +119,4 @@ affinity:
   session: {}
   storage: {}
   api: {}
-
-service:
-  type: ClusterIP
-  port: 80
+  telemetryDemo: {}

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -91,6 +91,11 @@ To optimise storage performance and reduce the need for database synchronization
 }
 
 `session:${ID}:storage` = string                    // storage ID
+
+`session:${ID}:telemetry.creation` = Hashes {
+	traceID = string								// root span / trace ID
+	context = string								// serialized span context
+}
 ```
 
 #### Log event codes

--- a/test/otel-collector-config.yaml
+++ b/test/otel-collector-config.yaml
@@ -1,0 +1,35 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+
+exporters:
+  logging:
+    loglevel: debug
+
+  jaeger:
+    endpoint: jaeger-all-in-one:14250
+    insecure: true
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]

--- a/test/tracing-compose.yml
+++ b/test/tracing-compose.yml
@@ -1,0 +1,31 @@
+version: "2"
+services:
+  # Jaeger
+  jaeger-all-in-one:
+    image: jaegertracing/all-in-one:latest
+    container_name: webgrid-jaeger
+    ports:
+      - "16686:16686"
+      - "14268"
+      - "14250"
+
+  # Collector
+  otel-collector:
+    image: otel/opentelemetry-collector-dev:latest
+    container_name: webgrid-otelcol
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "1888:1888" # pprof extension
+      - "13133:13133" # health_check extension
+      - "4317:4317" # OTLP gRPC receiver
+      - "55681:55681" # OTLP HTTP receiver
+      - "55670:55679" # zpages extension
+    depends_on:
+      - jaeger-all-in-one
+
+networks:
+  default:
+    external:
+      name: webgrid


### PR DESCRIPTION
### 🔧 Changes
This PR adds basic support for request tracing using OpenTelemetry. Each service now has the `--trace-endpoint` option which takes the address of a OpenTelemetry Collectors gRPC endpoint. All collected spans will then be pushed there. If the option is omitted, tracing will be disabled and instructions replaced with `no-op`.

Currently, every request is traced when tracing is enabled. In the future, configuration options for sampling will be added.

### 🚩 Related issues
Close #34 