### PR TITLE
Fix invalid docker repo link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,7 +74,7 @@ extra:
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/themegatb
     - icon: fontawesome/brands/docker
-      link: https://hub.docker.com/repositories/webgrid
+      link: https://hub.docker.com/u/webgrid
     - icon: fontawesome/brands/discord
       link: https://discord.gg/yYaPcNM
 


### PR DESCRIPTION
### 🔧 Changes

The previous footer link shows an authwall. The link was updated accordingly.

### ✅ Checklist
Follow this checklist — if you can't tick all boxed, create a draft PR first and address the remaining ones!
- [x] Check your commits adhere to the [requested structure](https://webgrid.dev/contribute/code-contrib/#commit-messages)
- [x] Rebase your branch onto the `main` branch, if there are conflicts
- [x] Add tests that show your bugfix or feature is effective
- [x] Write documentation (if applicable)