### PR TITLE
Add endpoint to fetch number of sessions in lifecycle range

### DIFF
--- a/core/modules/src/api/schema/types/session.rs
+++ b/core/modules/src/api/schema/types/session.rs
@@ -2,7 +2,7 @@ use super::super::GqlContext;
 use chrono::{DateTime, Utc};
 use domain::event::ProvisionerIdentifier;
 use domain::SessionMetadata;
-use juniper::{graphql_object, GraphQLObject};
+use juniper::{graphql_object, GraphQLEnum, GraphQLObject};
 
 #[derive(GraphQLObject)]
 pub struct MetadataEntry {
@@ -58,6 +58,34 @@ pub struct Video {
     playlist: String,
     /// Total number of bytes excluding metadata
     size: i32,
+}
+
+/// Lifecycle position of a session
+#[derive(GraphQLEnum)]
+pub enum SessionState {
+    /// Submitted by a client
+    Created,
+    /// Assigned to a provisioner
+    Scheduled,
+    /// Processed by the assigned provisioner and handed over to the infrastructure
+    Provisioned,
+    /// Up and running, ready to serve requests
+    Operational,
+    /// Completely shut down and no longer serving requests. Either due to explicit shutdown by client or due to crash.
+    Terminated,
+}
+
+impl SessionState {
+    /// Returns the database keys to use when querying for each state
+    pub fn database_key(&self) -> &str {
+        match self {
+            SessionState::Created => "createdAt",
+            SessionState::Scheduled => "scheduledAt",
+            SessionState::Provisioned => "provisionedAt",
+            SessionState::Operational => "operationalAt",
+            SessionState::Terminated => "terminatedAt",
+        }
+    }
 }
 
 pub struct Session {

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: ${REPOSITORY:-webgrid}/core:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: webgrid-orchestrator
-    command: orchestrator docker -p 5 --storage s3+http://webgrid:supersecretPasswordYouShouldChange@webgrid-s3:9000/webgrid?pathStyle DEADBEEF-0000-0000-0000-0000CAFEFEED "${REPOSITORY:-webgrid}/node-firefox:${IMAGE_TAG:-latest}=firefox::68.7.0esr,${REPOSITORY:-webgrid}/node-chrome:${IMAGE_TAG:-latest}=chrome::81.0.4044.122"
+    command: orchestrator docker -p 2 --storage s3+http://webgrid:supersecretPasswordYouShouldChange@webgrid-s3:9000/webgrid?pathStyle DEADBEEF-0000-0000-0000-0000CAFEFEED "${REPOSITORY:-webgrid}/node-firefox:${IMAGE_TAG:-latest}=firefox::68.7.0esr,${REPOSITORY:-webgrid}/node-chrome:${IMAGE_TAG:-latest}=chrome::81.0.4044.122"
     depends_on:
       - redis
       - s3


### PR DESCRIPTION
### 🔧 Changes
This PR adds a new API endpoint which allows the client to fetch the current number of sessions in between two lifecycle stages. It allows e.g. to fetch the number of pending sessions or currently running sessions.
