### PR TITLE
Allow users to specifiy volume binds for docker containers

### DIFF
--- a/core/modules/src/orchestrator/mod.rs
+++ b/core/modules/src/orchestrator/mod.rs
@@ -54,6 +54,7 @@ impl Orchestrator {
                     provisioner_options.images.clone(),
                     !provisioner_options.retain_exited_sessions,
                     provisioner_options.storage,
+                    provisioner_options.volume,
                     provisioner_options.log,
                 )
                 .unwrap();

--- a/core/modules/src/orchestrator/options.rs
+++ b/core/modules/src/orchestrator/options.rs
@@ -75,6 +75,11 @@ pub struct DockerOptions {
         value_name = "sessionLevel"
     )]
     pub log: String,
+
+    /// Volume binds for session containers using the docker format (e.g. /tmp/onHost:/insideContainer).
+    /// Using this option is not recommended and it will be deprecated at a later point.
+    #[structopt(env, long)]
+    pub volume: Vec<String>,
 }
 
 #[derive(Debug, StructOpt)]

--- a/core/modules/src/orchestrator/provisioner/docker.rs
+++ b/core/modules/src/orchestrator/provisioner/docker.rs
@@ -44,6 +44,7 @@ pub struct DockerProvisioner {
     instance: Uuid,
     auto_remove: bool,
     storage: Option<String>,
+    binds: Vec<String>,
     log: String,
 }
 
@@ -53,6 +54,7 @@ impl DockerProvisioner {
         images: ContainerImageSet,
         auto_remove: bool,
         storage: Option<String>,
+        binds: Vec<String>,
         log: String,
     ) -> Result<Self, bollard::errors::Error> {
         if images.is_empty() {
@@ -68,6 +70,7 @@ impl DockerProvisioner {
             instance,
             auto_remove,
             storage,
+            binds,
             log,
         })
     }
@@ -136,6 +139,7 @@ impl DockerProvisioner {
             auto_remove: Some(self.auto_remove),
             network_mode: Some("webgrid".to_string()),
             shm_size: Some(1024 * 1024 * 1024 * 2),
+            binds: Some(self.binds.clone()),
             ..Default::default()
         };
 


### PR DESCRIPTION
### 🔧 Changes
Adds a new docker-specific, repeatable `--volume` CLI option which allows users to add host volume binds to the created session containers.

### 🚩 Related issues
Closes #68 
