### PR TITLE
Allow custom name for K8s service

### DIFF
--- a/distribution/kubernetes/demo/charts/webgrid/templates/NOTES.txt
+++ b/distribution/kubernetes/demo/charts/webgrid/templates/NOTES.txt
@@ -1,1 +1,1 @@
-A service named {{ include "web-grid.fullname" . }} has been created. Point your selenium client to it (either by running it in K8s or creating an Ingress)!
+A service named {{ include "web-grid.serviceName" . }} has been created. Point your selenium client to it (either by running it in K8s or creating an Ingress)!

--- a/distribution/kubernetes/demo/charts/webgrid/templates/_helpers.tpl
+++ b/distribution/kubernetes/demo/charts/webgrid/templates/_helpers.tpl
@@ -93,6 +93,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name for the service
+*/}}
+{{- define "web-grid.serviceName" -}}
+{{- default (include "web-grid.fullname" .) .Values.service.name }}
+{{- end }}
+
+{{/*
 Allow customization of the image tag used
 */}}
 {{- define "web-grid.imageTag" -}}

--- a/distribution/kubernetes/demo/charts/webgrid/templates/gangway.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/templates/gangway.yaml
@@ -76,20 +76,3 @@ spec:
               port: status
           resources:
             {{- toYaml .Values.resources.gangway | nindent 12 }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "web-grid.fullname" . }}
-  labels:
-    {{- include "web-grid.labels" . | nindent 4 }}
-spec:
-  type: {{ .Values.service.type }}
-  ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  selector:
-    dev.webgrid/component: gangway
-    {{- include "web-grid.selectorLabels" . | nindent 4 }}

--- a/distribution/kubernetes/demo/charts/webgrid/templates/service.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "web-grid.serviceName" . }}
+  labels:
+    {{- include "web-grid.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    dev.webgrid/component: gangway
+    {{- include "web-grid.selectorLabels" . | nindent 4 }}

--- a/distribution/kubernetes/demo/charts/webgrid/values.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/values.yaml
@@ -7,6 +7,7 @@ logLevel: info,hyper=warn,warp=warn,sqlx=warn,tower=warn,h2=warn
 service:
   type: ClusterIP
   port: 80
+  name: ""
 
 config:
   # When set, sessions will be provided with this backend enabling video recording.
@@ -79,6 +80,7 @@ config:
       segmentDuration: 6
 
 replicaCount:
+  api: 1
   gangway: 1
   manager: 1
   collector: 1


### PR DESCRIPTION
### 🔧 Changes
This PR makes a slight adjustment to the helm chart which allows users to overwrite the name of the service created for webgrid. Pretty straight-forward 🤷 