### PR TITLE
Implement graceful shutdown for gangway

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1346,9 +1346,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jatsl"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4afb57f73132ba7ec394a9e7c45857485e04a8ca7f6fcf83992e2598b75494"
+checksum = "7ac9a4b9855a31fd3babefade12ee07d669b28ad68a627867d8f5734703f55e8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/core/harness/Cargo.toml
+++ b/core/harness/Cargo.toml
@@ -25,4 +25,4 @@ redis = { version = "0.20.2-alpha.0", default-features = false, features = ["tok
 # Other webgrid crates
 domain = { path = "../domain" }
 library = { path = "../library" }
-jatsl = "0.1.9"
+jatsl = "0.2.0"

--- a/core/modules/Cargo.toml
+++ b/core/modules/Cargo.toml
@@ -48,7 +48,7 @@ rand = "0.8"
 library = { path = "../library" }
 domain = { path = "../domain" }
 harness = { path = "../harness" }
-jatsl = "0.1.9"
+jatsl = "0.2.0"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/core/modules/src/gangway/options.rs
+++ b/core/modules/src/gangway/options.rs
@@ -1,4 +1,6 @@
 use crate::options::{QueueingOptions, RedisOptions, StorageOptions};
+use library::helpers::parse_seconds;
+use std::time::Duration;
 use structopt::StructOpt;
 
 /// Options for the gangway module
@@ -26,6 +28,10 @@ pub struct Options {
     /// Options regarding storage
     #[structopt(flatten)]
     pub storage: StorageOptions,
+
+    /// Grace period for running HTTP requests to complete before quitting
+    #[structopt(long, env, default_value = "600", parse(try_from_str = parse_seconds))]
+    pub termination_grace_period: Duration,
 }
 
 #[derive(Debug, StructOpt)]

--- a/core/modules/src/orchestrator/mod.rs
+++ b/core/modules/src/orchestrator/mod.rs
@@ -39,7 +39,10 @@ impl Orchestrator {
             BoxedMatchingStrategy,
         ) = match command.provisioner {
             ProvisionerCommand::Kubernetes(provisioner_options) => {
-                let provisioner = KubernetesProvisioner::new(provisioner_options.images.clone());
+                let provisioner = KubernetesProvisioner::new(
+                    provisioner_options.images.clone(),
+                    provisioner_options.orchestrator.queueing.id.clone(),
+                );
 
                 (
                     provisioner_options.orchestrator,
@@ -52,6 +55,7 @@ impl Orchestrator {
             ProvisionerCommand::Docker(provisioner_options) => {
                 let provisioner = DockerProvisioner::new(
                     provisioner_options.images.clone(),
+                    provisioner_options.orchestrator.queueing.id.clone(),
                     !provisioner_options.retain_exited_sessions,
                     provisioner_options.storage,
                     provisioner_options.volume,

--- a/core/modules/src/orchestrator/provisioner/docker.rs
+++ b/core/modules/src/orchestrator/provisioner/docker.rs
@@ -41,7 +41,7 @@ enum DockerProvisionerError {
 pub struct DockerProvisioner {
     docker: Docker,
     images: ContainerImageSet,
-    instance: Uuid,
+    instance: String,
     auto_remove: bool,
     storage: Option<String>,
     binds: Vec<String>,
@@ -52,6 +52,7 @@ impl DockerProvisioner {
     /// Creates a new instance with the provided images, connecting to the default docker instance
     pub fn new(
         images: ContainerImageSet,
+        instance: String,
         auto_remove: bool,
         storage: Option<String>,
         binds: Vec<String>,
@@ -62,7 +63,6 @@ impl DockerProvisioner {
         }
 
         let connection = Docker::connect_with_local_defaults()?;
-        let instance = Uuid::new_v4();
 
         Ok(Self {
             docker: connection,

--- a/core/modules/src/orchestrator/provisioner/kubernetes.rs
+++ b/core/modules/src/orchestrator/provisioner/kubernetes.rs
@@ -42,19 +42,18 @@ enum KubernetesProvisionerError {
 pub struct KubernetesProvisioner {
     namespace: String,
     images: ContainerImageSet,
-    instance: Uuid,
+    instance: String,
 }
 
 impl KubernetesProvisioner {
     /// Creates a new instance with the provided images, connecting to the default API endpoint drawn from the environment.
     /// By default, it uses the `webgrid` namespace unless the `NAMESPACE` variable is set (which it is by default in K8s pods).
-    pub fn new(images: ContainerImageSet) -> Self {
+    pub fn new(images: ContainerImageSet, instance: String) -> Self {
         if images.is_empty() {
             warn!("No images provided to provisioner. It won't be able to launch any sessions!");
         }
 
         let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| "webgrid".into());
-        let instance = Uuid::new_v4();
 
         Self {
             namespace,

--- a/distribution/kubernetes/demo/charts/webgrid/templates/gangway.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/templates/gangway.yaml
@@ -35,6 +35,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ add .Values.config.gangway.terminationGracePeriod 20 }}
       containers:
         - image: "{{ .Values.image.repository }}/core:{{ include "web-grid.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -56,6 +57,8 @@ spec:
               value: "{{ .Values.config.gangway.cacheSize }}"
             - name: PENDING_REQUEST_LIMIT
               value: "{{ .Values.config.gangway.pendingRequestLimit }}"
+            - name: TERMINATION_GRACE_PERIOD
+              value: "{{ .Values.config.gangway.terminationGracePeriod }}"
             - name: ID
               valueFrom:
                 fieldRef:
@@ -71,6 +74,8 @@ spec:
             tcpSocket:
               port: status
           readinessProbe:
+            periodSeconds: 3
+            failureThreshold: 1
             httpGet:
               path: /status
               port: status

--- a/distribution/kubernetes/demo/charts/webgrid/templates/gangway.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/templates/gangway.yaml
@@ -81,3 +81,14 @@ spec:
               port: status
           resources:
             {{- toYaml .Values.resources.gangway | nindent 12 }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "web-grid.fullname" . }}-gangway
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      dev.webgrid/component: gangway
+      {{- include "web-grid.selectorLabels" . | nindent 6 }}

--- a/distribution/kubernetes/demo/charts/webgrid/values.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/values.yaml
@@ -85,11 +85,11 @@ config:
       segmentDuration: 6
 
 replicaCount:
-  api: 1
-  gangway: 1
-  manager: 1
-  collector: 1
-  orchestrator: 1
+  api: 2
+  gangway: 2
+  manager: 2
+  collector: 2
+  orchestrator: 2
 
 image:
   repository: webgrid

--- a/distribution/kubernetes/demo/charts/webgrid/values.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/values.yaml
@@ -38,6 +38,11 @@ config:
     # In reality, this variable is only here to cap the memory usage and not to actively control the requests.
     # When you are hitting this limit you should probably start scaling horizontally instead.
     pendingRequestLimit: 25000
+    # Maximum amount of time for queued session requests to be processed before the gangway shuts down.
+    # You should set this to a rather high value so that all pending requests can still be completed while
+    # new ones are delegated to another replica instance. Note that the K8s terminationGracePeriod is set to
+    # this value plus 20sec and the gangway is instructed to terminate within the set time period.
+    terminationGracePeriod: 600
   collector:
     # Name of the mongo database to use
     database: webgrid


### PR DESCRIPTION
### 🔧 Changes
This PR introduces a number of changes that ensure a clean in-place no-disruption update process. Namely:

- K8s orchestrator now remembers which pods were deployed by it across restarts (no more orphaned pods)
- Gangway properly supports a graceful shutdown so no requests are left unserved
- `PodDisruptionBudgets` have been introduced to prevent any unintended outages