### PR TITLE
Implement performance profiler for node containers

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b21b63ab5a0db0369deb913540af2892750e42d949faacc7a61495ac418a1692"
+checksum = "83137067e3a2a6a06d67168e49e68a0957d215410473a740cea95a2425c0b7c6"
 dependencies = [
  "async-io",
  "blocking",
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+checksum = "046e47d4b2d391b1f6f8b407b1deb8dee56c1852ccd868becf2710f601b5f427"
 dependencies = [
  "async-channel",
  "async-task",
@@ -1030,6 +1030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a653442b9bdd11a77d3753a60443c60c4437d3acac8e6c3d4a6a9acd7cceed"
 dependencies = [
  "heim-common",
+ "heim-net",
  "heim-process",
  "heim-runtime",
 ]
@@ -1536,6 +1537,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "heim",
  "hyper",
  "lazy_static",
  "lru",
@@ -2112,9 +2114,9 @@ checksum = "cc77a3fc329982cbf3ea772aa265b742a550998bad65747c630406ee52dac425"
 
 [[package]]
 name = "polling"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
 dependencies = [
  "cfg-if",
  "libc",

--- a/core/domain/src/event/session/terminated.rs
+++ b/core/domain/src/event/session/terminated.rs
@@ -2,8 +2,9 @@ use super::super::super::QUEUE_SIZE_STARTUP_WORKFLOW;
 use super::SessionIdentifier;
 use library::communication::event::{Notification, QueueDescriptor};
 use library::communication::BlackboxError;
-use library::BoxedError;
+use library::{AccumulatedPerformanceMetrics, BoxedError};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::{
     fmt,
     fmt::{Error as FmtError, Formatter},
@@ -80,7 +81,7 @@ pub enum SessionTerminationReason {
 ///
 /// Whenever a session that has previously sent the [`SessionOperationalNotification`](super::SessionOperationalNotification)
 /// becomes unreachable permanently due to a particular [reason](SessionTerminationReason), this event is fired.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct SessionTerminatedNotification {
     /// Unique identifier of the created session
     pub id: SessionIdentifier,
@@ -90,6 +91,9 @@ pub struct SessionTerminatedNotification {
 
     /// Bytes of video recorded
     pub recording_bytes: usize,
+
+    /// Performance metrics collected for each process
+    pub profiling_data: HashMap<String, AccumulatedPerformanceMetrics>,
 }
 
 impl Notification for SessionTerminatedNotification {
@@ -105,6 +109,7 @@ impl SessionTerminatedNotification {
             id,
             reason: SessionTerminationReason::StartupFailed { error },
             recording_bytes: 0,
+            profiling_data: HashMap::new(),
         }
     }
 }

--- a/core/domain/src/session.rs
+++ b/core/domain/src/session.rs
@@ -6,6 +6,7 @@ use super::event::{
 use bson::serde_helpers::uuid_as_binary;
 use chrono::{DateTime, Utc};
 use library::helpers::option_chrono_datetime_as_bson_datetime;
+use library::AccumulatedPerformanceMetrics;
 use serde::{Deserialize, Serialize};
 
 /// Indexable metadata for a session
@@ -55,6 +56,9 @@ pub struct SessionMetadata {
     /// Number of bytes used by the video recording
     pub recording_bytes: Option<i64>,
 
+    /// Performance metrics collected for each process
+    pub profiling_data: HashMap<String, AccumulatedPerformanceMetrics>,
+
     /// Reason why the session terminated
     pub termination: Option<SessionTerminationReason>,
 }
@@ -75,6 +79,7 @@ impl SessionMetadata {
             provisioner_metadata: None,
             client_metadata: HashMap::new(),
             recording_bytes: None,
+            profiling_data: HashMap::new(),
             termination: None,
         }
     }

--- a/core/domain/src/webdriver/instance.rs
+++ b/core/domain/src/webdriver/instance.rs
@@ -305,6 +305,13 @@ impl WebDriverInstance {
         self.socket_addr
     }
 
+    /// Fetches the process id of the webdriver instance.
+    /// Returns `None` when it is no longer running.
+    /// Note that this does not return the browser pid.
+    pub fn pid(&self) -> Option<u32> {
+        self.process.id()
+    }
+
     /// Attempts to kill the webdriver and waits for it to die in agony
     #[instrument(err, skip(self), fields(pid = ?self.process.id(), addr = ?self.socket_addr))]
     pub async fn kill(mut self) -> Result<(), IoError> {

--- a/core/library/Cargo.toml
+++ b/core/library/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 
 # Tracing, Metrics & Co.
 tracing = { git = "https://github.com/tokio-rs/tracing", version = "0.2", features = ["log"] }
+heim = { version = "0.1.0-rc.1", features = ["process", "net"] }
 
 # Data handling & caching
 rust-s3 = { version = "0.27.0-rc4", git = "https://github.com/durch/rust-s3" }

--- a/core/library/src/lib.rs
+++ b/core/library/src/lib.rs
@@ -15,6 +15,9 @@ pub mod helpers;
 pub mod http;
 pub mod storage;
 
+mod perfmon;
+pub use perfmon::{AccumulatedPerformanceMetrics, PerformanceMonitor, PerformanceMonitoringTarget};
+
 /// Generic error type
 pub type BoxedError = Box<dyn std::error::Error + Send + Sync + 'static>;
 

--- a/core/library/src/perfmon.rs
+++ b/core/library/src/perfmon.rs
@@ -1,0 +1,311 @@
+use super::BoxedError;
+use futures::StreamExt;
+#[cfg(target_os = "linux")]
+use heim::process::os::linux::ProcessExt;
+use heim::process::{self, Process, ProcessError, ProcessResult};
+use heim::units::information::byte;
+use heim::units::time::second;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+use tracing::{info, warn};
+
+/// Metrics about a process accumulated over a certain timespan
+#[allow(missing_docs)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+pub struct AccumulatedPerformanceMetrics {
+    /// Label given to the process by the observer
+    #[serde(skip)]
+    pub label: String,
+
+    // Intermediary fields to calculate derived metrics (e.g. mean)
+    #[serde(skip)]
+    memory_sample_count: u64,
+    #[serde(skip)]
+    memory_rss_total: u64,
+    #[serde(skip)]
+    memory_vms_total: u64,
+
+    // Mean memory
+    pub memory_rss_mean: u64,
+    pub memory_vms_mean: u64,
+
+    // Max memory
+    pub memory_rss_max: u64,
+    pub memory_vms_max: u64,
+
+    // Process time
+    pub cpu_time_usr: f64,
+    pub cpu_time_sys: f64,
+    pub wall_time: f64,
+
+    // Disk I/O
+    pub disk_read: u64,
+    pub disk_write: u64,
+}
+
+impl AccumulatedPerformanceMetrics {
+    fn new(label: String) -> Self {
+        Self {
+            label,
+            ..Default::default()
+        }
+    }
+
+    fn add(&mut self, sample: PerformanceMetrics) {
+        self.memory_sample_count += 1;
+        self.memory_rss_total += sample.memory_rss;
+        self.memory_vms_total += sample.memory_vms;
+
+        self.memory_rss_mean = self.memory_rss_total / self.memory_sample_count;
+        self.memory_vms_mean = self.memory_vms_total / self.memory_sample_count;
+
+        self.memory_rss_max = self.memory_rss_max.max(sample.memory_rss);
+        self.memory_vms_max = self.memory_vms_max.max(sample.memory_vms);
+
+        self.cpu_time_usr = sample.cpu_time_usr;
+        self.cpu_time_sys = sample.cpu_time_sys;
+        self.wall_time = sample.wall_time;
+
+        self.disk_read = sample.disk_read;
+        self.disk_write = sample.disk_write;
+    }
+}
+
+#[derive(Debug, Default)]
+struct PerformanceMetrics {
+    memory_rss: u64,
+    memory_vms: u64,
+
+    cpu_time_usr: f64,
+    cpu_time_sys: f64,
+    wall_time: f64,
+
+    disk_read: u64,
+    disk_write: u64,
+}
+
+/// Tool to collect [`AccumulatedPerformanceMetrics`] for a given process
+pub struct PerformanceMonitor;
+
+#[derive(Debug, Error)]
+enum PerformanceMonitorError {
+    #[error("memory field not found")]
+    MemFieldNotFound,
+}
+
+/// Type of target to monitor the performance of
+pub enum PerformanceMonitoringTarget {
+    /// Fetches information about the current cgroup. Requires a Linux host with cgroupfs v2 enabled. May not support all fields.
+    CurrentCgroup,
+    /// Currently running process, supported on all operating systems.
+    Process(Process),
+}
+
+impl PerformanceMonitor {
+    async fn sample_cgroup() -> Result<PerformanceMetrics, BoxedError> {
+        let cpu_sys_path = "/sys/fs/cgroup/cpuacct/cpuacct.usage_sys";
+        let cpu_usr_path = "/sys/fs/cgroup/cpuacct/cpuacct.usage_user";
+        let cpu_factor = 1.0 / 1_000_000_000.0; // values are in nanoseconds, we expect seconds
+
+        let mem_stat_path = "/sys/fs/cgroup/memory/memory.stat";
+        let mem_field = "total_rss ";
+
+        let cpu_time_sys_raw = tokio::fs::read_to_string(cpu_sys_path).await?;
+        let cpu_time_sys = cpu_time_sys_raw.trim().parse::<f64>()? * cpu_factor;
+
+        let cpu_time_usr_raw = tokio::fs::read_to_string(cpu_usr_path).await?;
+        let cpu_time_usr = cpu_time_usr_raw.trim().parse::<f64>()? * cpu_factor;
+
+        let memory_rss_raw = tokio::fs::read_to_string(mem_stat_path).await?;
+        let memory_rss = memory_rss_raw
+            .lines()
+            .filter(|l| l.contains(mem_field))
+            .map(|l| l.strip_prefix(mem_field))
+            .flatten()
+            .collect::<Vec<_>>()
+            .first()
+            .ok_or(PerformanceMonitorError::MemFieldNotFound)?
+            .trim()
+            .parse::<u64>()?;
+
+        let cgroup_root_process = process::get(1).await?;
+        let create_time_raw = cgroup_root_process.create_time().await?;
+        let create_time = Duration::from_secs_f64(create_time_raw.get::<second>());
+        let current_time = SystemTime::now().duration_since(UNIX_EPOCH)?;
+        let wall_time = (current_time - create_time).as_secs_f64();
+
+        Ok(PerformanceMetrics {
+            memory_rss,
+            memory_vms: 0,
+
+            cpu_time_usr,
+            cpu_time_sys,
+            wall_time,
+
+            disk_read: 0,
+            disk_write: 0,
+        })
+    }
+
+    async fn sample(process: &Process) -> Result<PerformanceMetrics, BoxedError> {
+        let memory = process.memory().await?;
+        let cpu_time = process.cpu_time().await?;
+        let create_time_raw = process.create_time().await?;
+        let io_counters = process.io_counters().await?;
+        #[cfg(target_os = "linux")]
+        let _net_io_counters = process.net_io_counters().await?;
+
+        let memory_rss = memory.rss().get::<byte>();
+        let memory_vms = memory.vms().get::<byte>();
+
+        let cpu_time_usr = cpu_time.user().get::<second>();
+        let cpu_time_sys = cpu_time.system().get::<second>();
+
+        let create_time = Duration::from_secs_f64(create_time_raw.get::<second>());
+        let current_time = SystemTime::now().duration_since(UNIX_EPOCH)?;
+        let wall_time = (current_time - create_time).as_secs_f64();
+
+        let disk_read = io_counters.bytes_read().get::<byte>();
+        let disk_write = io_counters.bytes_written().get::<byte>();
+
+        Ok(PerformanceMetrics {
+            memory_rss,
+            memory_vms,
+
+            cpu_time_usr,
+            cpu_time_sys,
+            wall_time,
+
+            disk_read,
+            disk_write,
+        })
+    }
+
+    /// Spawns a background worker that periodically samples a process
+    /// and adds the collected information to the [`AccumulatedPerformanceMetrics`] instance returned.
+    pub fn observe(
+        target: PerformanceMonitoringTarget,
+        label: String,
+        interval: Duration,
+    ) -> Arc<Mutex<AccumulatedPerformanceMetrics>> {
+        let metrics = Arc::new(Mutex::new(AccumulatedPerformanceMetrics::new(
+            label.clone(),
+        )));
+        let metrics_handle = metrics.clone();
+
+        tokio::spawn(async move {
+            info!(?label, "Profiling process");
+
+            loop {
+                let result = match &target {
+                    PerformanceMonitoringTarget::Process(p) => PerformanceMonitor::sample(p).await,
+                    PerformanceMonitoringTarget::CurrentCgroup => {
+                        PerformanceMonitor::sample_cgroup().await
+                    }
+                };
+
+                match result {
+                    Ok(sample) => {
+                        let mut metrics = metrics.lock().await;
+                        metrics.add(sample);
+                    }
+                    Err(error) => {
+                        warn!(?label, ?error, "Encountered error while sampling process");
+                        break;
+                    }
+                }
+
+                if let PerformanceMonitoringTarget::Process(process) = &target {
+                    if !process.is_running().await.unwrap_or(false) {
+                        break;
+                    }
+                }
+
+                sleep(interval).await;
+            }
+
+            info!(?label, "Stopped profiling process");
+        });
+
+        metrics_handle
+    }
+
+    /// Same as `observe` but attempts to fetch the process by its id
+    pub async fn observe_by_pid(
+        pid: i32,
+        label: String,
+        interval: Duration,
+    ) -> ProcessResult<Arc<Mutex<AccumulatedPerformanceMetrics>>> {
+        let process = process::get(pid).await?;
+        Ok(PerformanceMonitor::observe(
+            PerformanceMonitoringTarget::Process(process),
+            label,
+            interval,
+        ))
+    }
+
+    /// Same as `observe` but samples the currently running process
+    pub async fn observe_self(
+        label: String,
+        interval: Duration,
+    ) -> ProcessResult<Arc<Mutex<AccumulatedPerformanceMetrics>>> {
+        let pid = std::process::id() as i32;
+        println!("OWN PID: {}", pid);
+        PerformanceMonitor::observe_by_pid(pid, label, interval).await
+    }
+
+    /// Same as `observe` but attempts to fetch the process by its name
+    pub async fn observe_by_name(
+        name: String,
+        label: String,
+        interval: Duration,
+    ) -> ProcessResult<Arc<Mutex<AccumulatedPerformanceMetrics>>> {
+        let stream = heim::process::processes().await?;
+        tokio::pin!(stream);
+
+        while let Some(result) = stream.next().await {
+            if let Ok(process) = result {
+                if let Ok(actual_name) = process.name().await {
+                    if actual_name == name {
+                        return Ok(PerformanceMonitor::observe(
+                            PerformanceMonitoringTarget::Process(process),
+                            label,
+                            interval,
+                        ));
+                    }
+                }
+            }
+        }
+
+        Err(ProcessError::NoSuchProcess(-1))
+    }
+
+    /// Attempts to recursively find all child-processes of a given parent
+    pub async fn recursively_find_child_processes_of_pid(
+        parent_pid: i32,
+    ) -> ProcessResult<Vec<Process>> {
+        // We assume that the stream of processes is always in ascending pid order — that way we do not have to do multiple passes
+        let stream = heim::process::processes().await?;
+        tokio::pin!(stream);
+
+        let mut children_pids = Vec::new();
+        let mut children = Vec::new();
+
+        while let Some(result) = stream.next().await {
+            if let Ok(process) = result {
+                if let Ok(parent) = process.parent_pid().await {
+                    if parent == parent_pid || children_pids.contains(&parent) {
+                        children_pids.push(process.pid());
+                        children.push(process);
+                    }
+                }
+            }
+        }
+
+        Ok(children)
+    }
+}

--- a/core/modules/Cargo.toml
+++ b/core/modules/Cargo.toml
@@ -34,7 +34,7 @@ k8s-openapi = { version = "0.12", default-features = false, features = ["v1_21"]
 serde_yaml = "0.8"
 
 # Module implementations
-heim = { version = "0.1.0-rc.1", features = ["process"] }
+heim = { version = "0.1.0-rc.1", features = ["process", "net"] }
 tempfile = "3"
 hyper = { version = "0.14", features = ["full"] }
 mime_guess = "2.0"

--- a/core/modules/src/collector/services/termination.rs
+++ b/core/modules/src/collector/services/termination.rs
@@ -49,6 +49,7 @@ impl Consumer for TerminationWatcherService {
         let notification = notification.into_inner();
         metadata.termination = Some(notification.reason);
         metadata.recording_bytes = Some(notification.recording_bytes as i64);
+        metadata.profiling_data = notification.profiling_data;
 
         self.collection.insert_one(metadata, None).await?;
         self.staging_collection.delete_one(query, None).await?;

--- a/core/modules/src/node/options.rs
+++ b/core/modules/src/node/options.rs
@@ -50,6 +50,14 @@ pub struct Options {
     /// Options regarding storage
     #[structopt(flatten)]
     pub storage: StorageOptions,
+
+    /// Enables CPU, memory, and disk usage profiling of all involved processes
+    #[structopt(long, env)]
+    pub profile: bool,
+
+    /// Sets the interval at which profiled processes will be sampled
+    #[structopt(long, env, default_value = "1", parse(try_from_str = parse_seconds))]
+    pub profiler_sampling_interval: Duration,
 }
 
 /// WebDriver related options

--- a/distribution/kubernetes/demo/charts/webgrid/templates/nodeJobTemplate.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/templates/nodeJobTemplate.yaml
@@ -77,6 +77,12 @@ data:
                   value: "{{ .Values.config.node.startupTimeout }}"
                 - name: INITIAL_TIMEOUT
                   value: "{{ .Values.config.node.initialTimeout }}"
+                {{- if .Values.config.node.profiling.enable }}
+                - name: PROFILE
+                  value: "1"
+                - name: PROFILER_SAMPLING_INTERVAL
+                  value: "{{ .Values.config.node.profiling.samplingInterval }}"
+                {{- end }}
                 - name: IDLE_TIMEOUT
                   value: "{{ .Values.config.node.idleTimeout }}"
                 - name: RESOLUTION

--- a/distribution/kubernetes/demo/charts/webgrid/values.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/values.yaml
@@ -75,6 +75,13 @@ config:
     idleTimeout: 120
     # Screen resolution for sessions
     resolution: 1920x1080
+    # CPU, Mem, Disk profiling of involved processes
+    profiling:
+      # Whether to activate the profiler
+      # Note that this feature uses quite some CPU itself, depending on the samplingInterval below!
+      enable: true
+      # Interval at which the processes are sampled
+      samplingInterval: 1
     # Options related to video recording
     # Consult the ffmpeg documentation on how these parameters work
     # https://trac.ffmpeg.org/wiki/Encode/H.264


### PR DESCRIPTION
### 🔧 Changes
This PR adds a profiling tool to the node module. It allows the user to record CPU, memory, and disk statistics of all relevant processes within the node container (sorry bash, you are irrelevant). Since this feature itself uses a non-negligible amount of CPU itself, the default sampling time has been chosen in a way that serves as a reasonable tradeoff. This feature is enabled by default and the resulting data will be attached to the session object in the database. API integration will follow.