### PR TITLE
Fix subchart of demo chart not having correct version

### DIFF
--- a/core/harness/src/redis/resource/mod.rs
+++ b/core/harness/src/redis/resource/mod.rs
@@ -11,6 +11,7 @@ mod conlike;
 mod multiplexed;
 mod owned;
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Eq, PartialEq)]
 enum CommandParseMode {
     ArgumentCount,

--- a/distribution/kubernetes/demo/charts/webgrid/templates/redis.yaml
+++ b/distribution/kubernetes/demo/charts/webgrid/templates/redis.yaml
@@ -13,7 +13,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100M
+      storage: 500M
 ---
 {{- end }}
 apiVersion: v1

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,6 +1,13 @@
 import shutil
 import os
 
+def on_pre_build(config):
+    # Make sure the chart version is set correctly
+    # This is necessary because the Helm package `--version` flag only changes the
+    # root chart version but not the subcharts. Thus we need to manually overwrite it!
+    print("Running pre-build hook!")
+    update_chart_version()
+
 def on_post_build(*args, **kwargs):
     site_dir = kwargs['config']['site_dir']
 
@@ -27,4 +34,22 @@ def copy_docker_compose(site_dir):
 
     # Write the file out again
     with open(dst_file, 'w') as file:
+        file.write(filedata)
+
+def update_chart_version():
+    chart = "distribution/kubernetes/demo/charts/webgrid/Chart.yaml"
+
+    # Read in the file
+    with open(chart, 'r') as file :
+        filedata = file.read()
+
+    # Use the git ref in GitHub Actions
+    git_ref = os.getenv('GITHUB_REF')
+    if git_ref is not None and git_ref.startswith('refs/tags/'):
+        version = git_ref[10:]
+        filedata = filedata.replace('v0.0.0-tempversion', version)
+        print("Overwriting Helm subchart version with git tag '" + version + "'")
+
+    # Write the file out again
+    with open(chart, 'w') as file:
         file.write(filedata)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ plugins:
       helm_repo_url: https://webgrid.dev/
   - mkdocs-simple-hooks:
       hooks:
+        on_pre_build: "docs.hooks:on_pre_build"
         on_post_build: "docs.hooks:on_post_build"
 
 extra_javascript:


### PR DESCRIPTION
### 🔧 Changes
Using Helm subcharts is a pain in the back side. When packaging, the `--version` and `appVersion` equivalent flag only overwrite the version of the main chart. Very unfortunate. This results in the subchart still using `v0.0.0-tempversion` and images are being pulled with that tag. Obviously does not work.

To remedy this in the short-term, a mkdocs pre-build hook has been added which search-and-replaces the version in the file. Certainly not ideal, but workable for now. Caution though as it changes the files in the repository so if you run mkdocs locally now, it will alter your working copy!

Additionally, a minor hotfix is included which increases the Redis PVC size to 500MB (up from 100). In production we encountered scenarios where the combined RDB+AOF persistence temporarily used more than 100MB yielding `no space left on device` errors, in turn dead-locking the whole grid as Redis entered safe-mode. Unfortunate 😆 