### PR TITLE
Add support for `/se/file` extension command

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +64,23 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
+dependencies = [
+ "bzip2",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "xz2",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -156,6 +179,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "async_zip"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f097e41c708183a28347e6fc332fc013248715cb8cb8836ca6d829f27a6902"
+dependencies = [
+ "async-compression",
+ "chrono",
+ "crc32fast",
+ "tokio",
 ]
 
 [[package]]
@@ -364,6 +399,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +528,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -713,6 +778,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1625,6 +1702,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb4b7c3eddad11d3af9e86c487607d2d2442d185d848575365c4856ba96d619"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "macaddr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1808,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,6 +1845,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "async_zip",
+ "base64",
  "bollard",
  "chrono",
  "domain",
@@ -3619,10 +3719,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
+name = "xz2"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zstd"
+version = "0.7.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "3.1.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.5.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/core/modules/Cargo.toml
+++ b/core/modules/Cargo.toml
@@ -43,6 +43,8 @@ juniper = "0.15"
 juniper_warp = "0.7"
 lru = "0.6"
 rand = "0.8"
+async_zip = "0.0.3"
+base64 = "0.13"
 
 # Other webgrid crates
 library = { path = "../library" }

--- a/core/modules/src/node/proxy/file_upload.rs
+++ b/core/modules/src/node/proxy/file_upload.rs
@@ -1,0 +1,130 @@
+use async_trait::async_trait;
+use async_zip::error::ZipError;
+use async_zip::read::mem::ZipFileReader;
+use futures::Future;
+use harness::HeartStone;
+use hyper::header::CONTENT_TYPE;
+use hyper::{
+    http::{request::Parts, Method, Response},
+    Body,
+};
+use library::http::Responder;
+use serde::Deserialize;
+use serde_json::json;
+use std::convert::Infallible;
+use std::net::IpAddr;
+use std::sync::Arc;
+use tempfile::{tempdir, TempDir};
+use thiserror::Error;
+use tokio::fs::File;
+use tokio::io::copy;
+use tokio::sync::Mutex;
+use tracing::debug;
+
+#[derive(Deserialize)]
+struct FileUploadRequest {
+    file: String,
+}
+
+#[derive(Debug, Error)]
+enum FileUploadInterceptorError {
+    #[error("failed unpacking archive {0:?}")]
+    InvalidArchive(ZipError),
+    #[error("incomplete request body")]
+    UploadError(#[from] hyper::Error),
+    #[error("invalid request format")]
+    RequestFormatInvalid(#[from] serde_json::Error),
+    #[error("invalid base64 encoded file string")]
+    FileStringInvalid(#[from] base64::DecodeError),
+}
+
+pub struct FileUploadInterceptor {
+    heart_stone: Arc<Mutex<HeartStone>>,
+    session_id: String,
+    file_handles: Arc<Mutex<Vec<TempDir>>>,
+}
+
+impl FileUploadInterceptor {
+    pub fn new(heart_stone: HeartStone, session_id: String) -> Self {
+        Self {
+            heart_stone: Arc::new(Mutex::new(heart_stone)),
+            session_id,
+            file_handles: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    async fn handle_body(&self, body: Body) -> Result<String, FileUploadInterceptorError> {
+        let request_bytes = hyper::body::to_bytes(body).await?;
+        let request: FileUploadRequest = serde_json::from_slice(&request_bytes)?;
+        let bytes = base64::decode(&request.file)?;
+
+        // Get a handle on the first file in the ZIP
+        let mut zip_reader = ZipFileReader::new(&bytes)
+            .await
+            .map_err(FileUploadInterceptorError::InvalidArchive)?;
+        let mut file_reader = zip_reader
+            .entry_reader(0)
+            .await
+            .map_err(FileUploadInterceptorError::InvalidArchive)?;
+
+        // Create a file on disk
+        let name = file_reader.entry().name();
+        let directory = tempdir().unwrap();
+        let file_path = directory.path().join(name);
+        let mut file_writer = File::create(&file_path).await.unwrap();
+
+        // Write the contents and retain the handle
+        copy(&mut file_reader, &mut file_writer).await.unwrap();
+        self.file_handles.lock().await.push(directory);
+
+        // Send the path to the caller
+        debug!(?file_path, "Received file upload from client");
+        Ok(file_path.display().to_string())
+    }
+}
+
+#[async_trait]
+impl Responder for FileUploadInterceptor {
+    #[inline]
+    async fn respond<F, Fut>(
+        &self,
+        parts: Parts,
+        body: Body,
+        client_ip: IpAddr,
+        next: F,
+    ) -> Result<Response<Body>, Infallible>
+    where
+        Fut: Future<Output = Result<Response<Body>, Infallible>> + Send,
+        F: FnOnce(Parts, Body, IpAddr) -> Fut + Send,
+    {
+        // Reset the lifetime
+        self.heart_stone.lock().await.reset_lifetime().await;
+
+        // Check if it is a file upload request
+        let method = &parts.method;
+        let path = parts.uri.path();
+
+        let is_file_upload_request = method == Method::POST
+            && path.eq_ignore_ascii_case(&format!("/session/{}/se/file", self.session_id));
+
+        // Handle the file and json-ify the result
+        if is_file_upload_request {
+            let response_value = match self.handle_body(body).await {
+                Ok(path) => json!({ "value": path }),
+                Err(e) => json!({
+                    "status": "error",
+                    "error": e.to_string()
+                }),
+            };
+
+            // Build a json response and send it
+            let response = serde_json::to_string(&response_value).unwrap_or_else(|_| "{}".into());
+            Ok(Response::builder()
+                .header(CONTENT_TYPE, "application/json")
+                .body(response.into())
+                .unwrap())
+        } else {
+            next(parts, body, client_ip).await
+        }
+    }
+}

--- a/core/modules/src/node/proxy/metadata_extension.rs
+++ b/core/modules/src/node/proxy/metadata_extension.rs
@@ -3,6 +3,7 @@ use domain::event::SessionClientMetadata;
 use futures::Future;
 use harness::HeartStone;
 use hyper::body::to_bytes;
+use hyper::header::CONTENT_TYPE;
 use hyper::{
     http::{request::Parts, Method, Response},
     Body,
@@ -103,6 +104,9 @@ impl Responder for MetadataExtensionInterceptor {
 
         // Build a json response and send it
         let response = serde_json::to_string(&response_value).unwrap_or_else(|_| "{}".into());
-        Ok(Response::builder().body(response.into()).unwrap())
+        Ok(Response::builder()
+            .header(CONTENT_TYPE, "application/json")
+            .body(response.into())
+            .unwrap())
     }
 }


### PR DESCRIPTION
### 🔧 Changes
When uploading a file with a locally running browser, one passes the path to a file. Since both browser and client run on the same machine, this works as expected. However, in the case of remote browsers, this does not hold true anymore. To work around this issue, the core selenium team introduced a "workaround" in the form of an extension command at `/se/file` (used to be just `/file`).

This extension command takes a JSON object that looks like this:
```json
{
  "file": "<base64-zip>"
}
```
The content string is a base64 encoded zip file containing a single file. At this stage, it is not known what would happen when the archive contains multiple files. Thus WebGrid will throw an error for now as it would result in undefined behaviour.

When received, the remote endpoint dumps the file into a temporary directory on disk and returns the path to it in a JSON response like this:
```json
{
  "value": "/path/to/somewhere/file.txt"
}
```
Note that the filename and extension are equal to the ones in the archive in all observed cases. Thus it is assumed to be a requirement and if such a file can not be created, it will be considered an error. To make this unlikely, the implementation in this PR dumps each uploaded file in its own unique, temporary directory.

Additionally, it turned out to be important that all responses have the `Content-Type` header set to `application/json`. If it is missing, the java selenium client will not interpret the response. However, neither does it print an error. It just sets all fields to `null` 🤷 

